### PR TITLE
Refactor: 법정동 데이터 API 분리

### DIFF
--- a/src/main/java/org/guzzing/studayserver/domain/region/controller/RegionRestController.java
+++ b/src/main/java/org/guzzing/studayserver/domain/region/controller/RegionRestController.java
@@ -15,6 +15,7 @@ import org.guzzing.studayserver.domain.region.service.dto.beopjungdong.Upmyeondo
 import org.guzzing.studayserver.domain.region.service.dto.location.RegionResult;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,19 +30,40 @@ public class RegionRestController {
         this.regionService = regionService;
     }
 
+    @GetMapping(path = "/beopjungdong", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<RegionResponse> getSido() {
+        SidoResult result = regionService.findSido();
+
+        return ResponseEntity
+                .status(OK)
+                .body(RegionResponse.from(result));
+
+    }
+
+    @ValidSido
+    @GetMapping(path = "/beopjungdong/{sido}", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<RegionResponse> getSigungu(
+            @PathVariable String sido
+    ) {
+        SigunguResult result = regionService.findSigungusBySido(sido);
+
+        return ResponseEntity
+                .status(OK)
+                .body(RegionResponse.from(result));
+    }
+
     @ValidSido
     @ValidSigungu
-    @GetMapping(path = "/beopjungdong", produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<RegionResponse> getSubRegions(
-            @RequestParam(required = false) String sido,
-            @RequestParam(required = false) String sigungu
+    @GetMapping(path = "/beopjungdong/{sido}/{sigungu}", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<RegionResponse> getUpmyeondong(
+            @PathVariable String sido,
+            @PathVariable String sigungu
     ) {
-        if (sido == null) {
-            return getSidoData();
-        } else if (sigungu == null) {
-            return getSigunguData(sido);
-        }
-        return getUpmyeondongData(sido, sigungu);
+        UpmyeondongResult result = regionService.findUpmyeondongBySidoAndSigungu(sido, sigungu);
+
+        return ResponseEntity
+                .status(OK)
+                .body(RegionResponse.from(result));
     }
 
     @ValidSido
@@ -57,27 +79,6 @@ public class RegionRestController {
         return ResponseEntity
                 .status(OK)
                 .body(RegionLocationResponse.from(regionResult));
-    }
-
-    private ResponseEntity<RegionResponse> getUpmyeondongData(String sido, String sigungu) {
-        UpmyeondongResult result = regionService.findUpmyeondongBySidoAndSigungu(sido, sigungu);
-        return ResponseEntity
-                .status(OK)
-                .body(RegionResponse.from(result));
-    }
-
-    private ResponseEntity<RegionResponse> getSigunguData(String sido) {
-        SigunguResult result = regionService.findSigungusBySido(sido);
-        return ResponseEntity
-                .status(OK)
-                .body(RegionResponse.from(result));
-    }
-
-    private ResponseEntity<RegionResponse> getSidoData() {
-        SidoResult result = regionService.findSido();
-        return ResponseEntity
-                .status(OK)
-                .body(RegionResponse.from(result));
     }
 
 }

--- a/src/test/java/org/guzzing/studayserver/domain/region/controller/RegionRestControllerTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/region/controller/RegionRestControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -57,70 +58,6 @@ class RegionRestControllerTest {
     }
 
     @Test
-    @DisplayName("시도를 파라미터로 요청하면 해당 시도, 시군구, 개수 데이터를 반환한다.")
-    @WithMockCustomOAuth2LoginUser
-    void getSubRegions_Sido_RegionResponse() throws Exception {
-        // Given & When
-        ResultActions perform = mockMvc.perform(get("/regions/beopjungdong")
-                .param("sido", sido)
-                .contentType(APPLICATION_JSON_VALUE)
-                .accept(APPLICATION_JSON_VALUE));
-
-        // Then
-        perform.andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.targetRegion").value(sido))
-                .andExpect(jsonPath("$.subRegion").isNotEmpty())
-                .andExpect(jsonPath("$.subRegionCount").isNumber())
-                .andDo(document("get-region-beopjungdong-sigungu",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        queryParameters(
-                                parameterWithName("sido").description("시도")
-                        ),
-                        responseFields(
-                                fieldWithPath("targetRegion").type(STRING).description("탐색한 시도명"),
-                                fieldWithPath("subRegion").type(ARRAY).description("탐색한 시군구 조회 결과 리스트"),
-                                fieldWithPath("subRegionCount").type(NUMBER).description("탐색한 시군구 조회 결과 수")
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("시도, 시군구를 요청 파라미터로 받아 해당 시도군구의 읍면동 데이터를 응답한다.")
-    @WithMockCustomOAuth2LoginUser
-    void getSubRegions_SidoAndSigungu_RegionResponse() throws Exception {
-        // Given & When
-        ResultActions perform = mockMvc.perform(get("/regions/beopjungdong")
-                .param("sido", sido)
-                .param("sigungu", sigungu)
-                .contentType(APPLICATION_JSON_VALUE)
-                .accept(APPLICATION_JSON_VALUE));
-
-        // Then
-        perform.andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.targetRegion").value(sido + " " + sigungu))
-                .andExpect(jsonPath("$.subRegion").isNotEmpty())
-                .andExpect(jsonPath("$.subRegionCount").isNumber())
-                .andDo(document("get-region-beopjungdong-upmyeondong",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        queryParameters(
-                                parameterWithName("sido").description("시도"),
-                                parameterWithName("sigungu").description("시군구")
-                        ),
-                        responseFields(
-                                fieldWithPath("targetRegion").type(STRING).description("탐색한 시도군구명"),
-                                fieldWithPath("subRegion").type(ARRAY).description("탐색한 읍면동 조회 결과 리스트"),
-                                fieldWithPath("subRegionCount").type(NUMBER).description("탐색한 읍면동 조회 결과 수")
-                        )
-                ));
-    }
-
-    @Test
     @DisplayName("아무런 파라미터 없이 요청하면 조회 가능한 시도 데이터를 반환한다.")
     @WithMockCustomOAuth2LoginUser
     void getSubRegions_None_RegionResponse() throws Exception {
@@ -143,6 +80,67 @@ class RegionRestControllerTest {
                                 fieldWithPath("targetRegion").type(STRING).description("전국"),
                                 fieldWithPath("subRegion").type(ARRAY).description("탐색 가능한 시도 조회 결과 리스트"),
                                 fieldWithPath("subRegionCount").type(NUMBER).description("탐색 가능한 시도 조회 결과 수")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("시도를 파라미터로 요청하면 해당 시도, 시군구, 개수 데이터를 반환한다.")
+    @WithMockCustomOAuth2LoginUser
+    void getSubRegions_Sido_RegionResponse() throws Exception {
+        // Given & When
+        ResultActions perform = mockMvc.perform(get("/regions/beopjungdong/{sido}", sido)
+                .contentType(APPLICATION_JSON_VALUE)
+                .accept(APPLICATION_JSON_VALUE));
+
+        // Then
+        perform.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.targetRegion").value(sido))
+                .andExpect(jsonPath("$.subRegion").isNotEmpty())
+                .andExpect(jsonPath("$.subRegionCount").isNumber())
+                .andDo(document("get-region-beopjungdong-sigungu",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("sido").description("시도")
+                        ),
+                        responseFields(
+                                fieldWithPath("targetRegion").type(STRING).description("탐색한 시도명"),
+                                fieldWithPath("subRegion").type(ARRAY).description("탐색한 시군구 조회 결과 리스트"),
+                                fieldWithPath("subRegionCount").type(NUMBER).description("탐색한 시군구 조회 결과 수")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("시도, 시군구를 요청 파라미터로 받아 해당 시도군구의 읍면동 데이터를 응답한다.")
+    @WithMockCustomOAuth2LoginUser
+    void getSubRegions_SidoAndSigungu_RegionResponse() throws Exception {
+        // Given & When
+        ResultActions perform = mockMvc.perform(get("/regions/beopjungdong/{sido}/{sigungu}", sido, sigungu)
+                .contentType(APPLICATION_JSON_VALUE)
+                .accept(APPLICATION_JSON_VALUE));
+
+        // Then
+        perform.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.targetRegion").value(sido + " " + sigungu))
+                .andExpect(jsonPath("$.subRegion").isNotEmpty())
+                .andExpect(jsonPath("$.subRegionCount").isNumber())
+                .andDo(document("get-region-beopjungdong-upmyeondong",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("sido").description("시도"),
+                                parameterWithName("sigungu").description("시군구")
+                        ),
+                        responseFields(
+                                fieldWithPath("targetRegion").type(STRING).description("탐색한 시도군구명"),
+                                fieldWithPath("subRegion").type(ARRAY).description("탐색한 읍면동 조회 결과 리스트"),
+                                fieldWithPath("subRegionCount").type(NUMBER).description("탐색한 읍면동 조회 결과 수")
                         )
                 ));
     }


### PR DESCRIPTION
### 변경 전 API
- 시도, 시군구, 읍면동 데이터 획득 API 하나로 통일

### 변경 후 API
- 시도 데이터 획득 : /regions/beopjungdong
- 시군구 데이터 획득 : /regions/beopjungdong/{sido}
- 읍면동 데이터 획득 : /regions/beopjungdong/{sido}/{sigungu}