### PR TITLE
달력 표시 정보 조회와 하루 일정 기능 구현

### DIFF
--- a/src/main/java/org/guzzing/studayserver/domain/academy/repository/lesson/LessonJpaRepository.java
+++ b/src/main/java/org/guzzing/studayserver/domain/academy/repository/lesson/LessonJpaRepository.java
@@ -14,4 +14,9 @@ public interface LessonJpaRepository extends JpaRepository<Lesson, Long>, Lesson
 
     List<LessonInfoToCreateDashboard> findAllLessonInfoByAcademyId (Long academyId);
 
+
+    @Query("SELECT ls FROM Lesson AS ls "
+            + "JOIN FETCH ls.academy aca "
+            + "WHERE ls.id IN :lessonIds")
+    List<Lesson> findByIds(List<Long> lessonIds);
 }

--- a/src/main/java/org/guzzing/studayserver/domain/academy/repository/lesson/LessonRepository.java
+++ b/src/main/java/org/guzzing/studayserver/domain/academy/repository/lesson/LessonRepository.java
@@ -19,4 +19,5 @@ public interface LessonRepository {
 
     Optional<Lesson> findById(final Long lessonId);
 
+    List<Lesson> findByIds(List<Long> lessonIds);
 }

--- a/src/main/java/org/guzzing/studayserver/domain/academy/service/LessonReadService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/academy/service/LessonReadService.java
@@ -1,0 +1,32 @@
+package org.guzzing.studayserver.domain.academy.service;
+
+import java.util.List;
+import org.guzzing.studayserver.domain.academy.model.Lesson;
+import org.guzzing.studayserver.domain.academy.repository.lesson.LessonRepository;
+import org.guzzing.studayserver.domain.academy.service.dto.result.LessonFindByIdsResults;
+import org.guzzing.studayserver.domain.academy.service.dto.result.LessonFindByIdsResults.LessonFindByIdsResult;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LessonReadService {
+
+    private final LessonRepository lessonRepository;
+
+    public LessonReadService(LessonRepository lessonRepository) {
+        this.lessonRepository = lessonRepository;
+    }
+
+
+    public LessonFindByIdsResults findByIds(List<Long> lessonIds) {
+        List<Lesson> lessons = lessonRepository.findByIds(lessonIds);
+
+        List<LessonFindByIdsResult> lessonFindByIdsResults = lessons.stream()
+                .map(l -> new LessonFindByIdsResult(
+                        l.getId(),
+                        l.getAcademy().getAcademyName(),
+                        l.getSubject()
+                )).toList();
+
+        return new LessonFindByIdsResults(lessonFindByIdsResults);
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/academy/service/dto/result/LessonFindByIdsResults.java
+++ b/src/main/java/org/guzzing/studayserver/domain/academy/service/dto/result/LessonFindByIdsResults.java
@@ -1,0 +1,17 @@
+package org.guzzing.studayserver.domain.academy.service.dto.result;
+
+import java.util.List;
+
+public record LessonFindByIdsResults(
+        List<LessonFindByIdsResult> lessons
+) {
+
+    public record LessonFindByIdsResult(
+            Long lessonId,
+            String academyName,
+            String lessonName
+    ) {
+
+
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/repository/academyschedule/AcademyScheduleJpaRepository.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/repository/academyschedule/AcademyScheduleJpaRepository.java
@@ -34,4 +34,14 @@ public interface AcademyScheduleJpaRepository extends JpaRepository<AcademySched
 
     void deleteAcademyScheduleById(Long academyScheduleId);
 
+
+    @Query("SELECT ash FROM AcademySchedule ash "
+            + "JOIN FETCH ash.academyTimeTemplate att "
+            + "WHERE att.childId IN :childIds "
+            + "AND YEAR(ash.scheduleDate) = :year "
+            + "AND MONTH(ash.scheduleDate) = :month")
+    List<AcademySchedule> findByYearMonth(
+            @Param("childIds") List<Long> childIds,
+            @Param("year") int year,
+            @Param("month") int month);
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/repository/academyschedule/AcademyScheduleJpaRepository.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/repository/academyschedule/AcademyScheduleJpaRepository.java
@@ -1,5 +1,7 @@
 package org.guzzing.studayserver.domain.calendar.repository.academyschedule;
 
+import java.time.LocalDate;
+import java.util.List;
 import org.guzzing.studayserver.domain.calendar.model.AcademySchedule;
 import org.guzzing.studayserver.domain.calendar.model.AcademyTimeTemplate;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,9 +9,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.List;
 
 public interface AcademyScheduleJpaRepository extends JpaRepository<AcademySchedule, Long>, AcademyScheduleRepository {
 
@@ -44,4 +43,10 @@ public interface AcademyScheduleJpaRepository extends JpaRepository<AcademySched
             @Param("childIds") List<Long> childIds,
             @Param("year") int year,
             @Param("month") int month);
+
+    @Query("SELECT ash FROM AcademySchedule ash "
+            + "JOIN FETCH ash.academyTimeTemplate att "
+            + "WHERE att.childId IN :childIds "
+            + "AND ash.scheduleDate = :date")
+    List<AcademySchedule> findByDate(List<Long> childIds, LocalDate date);
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/repository/academyschedule/AcademyScheduleRepository.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/repository/academyschedule/AcademyScheduleRepository.java
@@ -23,4 +23,6 @@ public interface AcademyScheduleRepository {
     void deleteAcademyScheduleById(Long academyScheduleId);
 
     List<AcademySchedule> findByYearMonth(List<Long> childIds, int year, int month);
+
+    List<AcademySchedule> findByDate(List<Long> childIds, LocalDate date);
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/repository/academyschedule/AcademyScheduleRepository.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/repository/academyschedule/AcademyScheduleRepository.java
@@ -22,4 +22,5 @@ public interface AcademyScheduleRepository {
 
     void deleteAcademyScheduleById(Long academyScheduleId);
 
+    List<AcademySchedule> findByYearMonth(List<Long> childIds, int year, int month);
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademyCalendarAccessService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademyCalendarAccessService.java
@@ -1,9 +1,9 @@
 package org.guzzing.studayserver.domain.calendar.service;
 
+import java.util.List;
 import org.guzzing.studayserver.domain.calendar.service.dto.param.AcademyCalendarDeleteParam;
 
 public interface AcademyCalendarAccessService {
 
     void deleteSchedule(AcademyCalendarDeleteParam academyCalendarDeleteParam);
-
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademyCalendarAccessServiceImpl.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademyCalendarAccessServiceImpl.java
@@ -1,5 +1,6 @@
 package org.guzzing.studayserver.domain.calendar.service;
 
+import java.util.List;
 import org.guzzing.studayserver.domain.calendar.service.dto.param.AcademyCalendarDeleteParam;
 import org.springframework.stereotype.Service;
 
@@ -15,5 +16,4 @@ public class AcademyCalendarAccessServiceImpl {
     public void deleteSchedule(AcademyCalendarDeleteParam academyCalendarDeleteParam) {
         academyCalendarService.deleteSchedule(academyCalendarDeleteParam);
     }
-
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademySchedulesReadService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademySchedulesReadService.java
@@ -1,8 +1,11 @@
 package org.guzzing.studayserver.domain.calendar.service;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.guzzing.studayserver.domain.calendar.model.AcademySchedule;
 import org.guzzing.studayserver.domain.calendar.repository.academyschedule.AcademyScheduleRepository;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleFindByDateResults;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleFindByDateResults.AcademyScheduleFindByDateResult;
 import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleYearMonthResults;
 import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleYearMonthResults.AcademyScheduleYearMonthResult;
 import org.springframework.stereotype.Service;
@@ -31,5 +34,20 @@ public class AcademySchedulesReadService {
                 .toList();
 
         return new AcademyScheduleYearMonthResults(academyScheduleYearMonthResults);
+    }
+
+    @Transactional(readOnly = true)
+    public AcademyScheduleFindByDateResults findByDate(List<Long> childIds, LocalDate date) {
+        List<AcademySchedule> academySchedules = academyScheduleRepository.findByDate(childIds, date);
+
+        List<AcademyScheduleFindByDateResult> academyScheduleResults = academySchedules.stream()
+                .map(ash -> new AcademyScheduleFindByDateResult(
+                        ash.getId(),
+                        ash.getLessonStartTime(),
+                        ash.getLessonEndTime(),
+                        ash.getAcademyTimeTemplate().getChildId()
+                )).toList();
+
+        return new AcademyScheduleFindByDateResults(academyScheduleResults);
     }
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademySchedulesReadService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademySchedulesReadService.java
@@ -45,7 +45,7 @@ public class AcademySchedulesReadService {
                         ash.getId(),
                         ash.getLessonStartTime(),
                         ash.getLessonEndTime(),
-                        ash.getAcademyTimeTemplate().getChildId()
+                        ash.getAcademyTimeTemplate().getDashboardId()
                 )).toList();
 
         return new AcademyScheduleFindByDateResults(academyScheduleResults);

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademySchedulesReadService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademySchedulesReadService.java
@@ -1,0 +1,35 @@
+package org.guzzing.studayserver.domain.calendar.service;
+
+import java.util.List;
+import org.guzzing.studayserver.domain.calendar.model.AcademySchedule;
+import org.guzzing.studayserver.domain.calendar.repository.academyschedule.AcademyScheduleRepository;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleYearMonthResults;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleYearMonthResults.AcademyScheduleYearMonthResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AcademySchedulesReadService {
+
+    private final AcademyScheduleRepository academyScheduleRepository;
+
+    public AcademySchedulesReadService(AcademyScheduleRepository academyScheduleRepository) {
+        this.academyScheduleRepository = academyScheduleRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public AcademyScheduleYearMonthResults getScheduleByYearMonth(List<Long> childIds, int year, int month) {
+        List<AcademySchedule> academySchedules = academyScheduleRepository.findByYearMonth(childIds, year, month);
+
+        List<AcademyScheduleYearMonthResult> academyScheduleYearMonthResults = academySchedules.stream()
+                .map(a -> new AcademyScheduleYearMonthResult(
+                        a.getAcademyTimeTemplate().getId(),
+                        a.getAcademyTimeTemplate().getChildId(),
+                        a.getId(),
+                        a.getScheduleDate()
+                ))
+                .toList();
+
+        return new AcademyScheduleYearMonthResults(academyScheduleYearMonthResults);
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademySchedulesReadService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/AcademySchedulesReadService.java
@@ -45,7 +45,8 @@ public class AcademySchedulesReadService {
                         ash.getId(),
                         ash.getLessonStartTime(),
                         ash.getLessonEndTime(),
-                        ash.getAcademyTimeTemplate().getDashboardId()
+                        ash.getAcademyTimeTemplate().getDashboardId(),
+                        ash.getAcademyTimeTemplate().getChildId()
                 )).toList();
 
         return new AcademyScheduleFindByDateResults(academyScheduleResults);

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/AcademyScheduleFindByDateResults.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/AcademyScheduleFindByDateResults.java
@@ -13,7 +13,8 @@ public record AcademyScheduleFindByDateResults(
             long academyScheduleId,
             LocalTime startTime,
             LocalTime endTime,
-            long dashboardId
+            long dashboardId,
+            Long childId
     ) {
 
     }

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/AcademyScheduleFindByDateResults.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/AcademyScheduleFindByDateResults.java
@@ -13,7 +13,7 @@ public record AcademyScheduleFindByDateResults(
             long academyScheduleId,
             LocalTime startTime,
             LocalTime endTime,
-            long childId
+            long dashboardId
     ) {
 
     }

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/AcademyScheduleFindByDateResults.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/AcademyScheduleFindByDateResults.java
@@ -1,0 +1,21 @@
+package org.guzzing.studayserver.domain.calendar.service.dto.result;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record AcademyScheduleFindByDateResults(
+        List<AcademyScheduleFindByDateResult> academySchedules
+) {
+
+
+    public record AcademyScheduleFindByDateResult(
+            long academyScheduleId,
+            LocalTime startTime,
+            LocalTime endTime,
+            long childId
+    ) {
+
+    }
+
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/AcademyScheduleYearMonthResults.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/AcademyScheduleYearMonthResults.java
@@ -1,0 +1,18 @@
+package org.guzzing.studayserver.domain.calendar.service.dto.result;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record AcademyScheduleYearMonthResults(
+        List<AcademyScheduleYearMonthResult> academyScheduleYearMonthResults
+) {
+
+    public record AcademyScheduleYearMonthResult(
+            Long academyTimeTemplateId,
+            Long childId,
+            Long academyScheduleId,
+            LocalDate scheduleDate
+    ) {
+
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/CalendarFindSchedulesByDateResults.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/CalendarFindSchedulesByDateResults.java
@@ -1,15 +1,45 @@
 package org.guzzing.studayserver.domain.calendar.service.dto.result;
 
+import java.time.LocalTime;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.guzzing.studayserver.domain.academy.service.dto.result.LessonFindByIdsResults.LessonFindByIdsResult;
+import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarFindSchedulesByDateIncompleteResult;
 
 public record CalendarFindSchedulesByDateResults(
         List<CalendarFindSchedulesByDateResult> results
 ) {
 
-    public record CalendarFindSchedulesByDateResult(
+    public CalendarFindSchedulesByDateResults(List<CalendarFindSchedulesByDateResult> results) {
+        this.results = results.stream()
+                .sorted(Comparator.comparing(CalendarFindSchedulesByDateResult::startTime)
+                        .thenComparing(CalendarFindSchedulesByDateResult::endTime))
+                .toList();
+    }
 
+    public record CalendarFindSchedulesByDateResult(
+            Long childId,
+            Long academyScheduleId,
+            LocalTime startTime,
+            LocalTime endTime,
+            Long lessonId,
+            String academyName,
+            String lessonName
     ) {
 
+        public static CalendarFindSchedulesByDateResult of(
+                CalendarFindSchedulesByDateIncompleteResult incompleteResult, LessonFindByIdsResult lesson) {
+            return new CalendarFindSchedulesByDateResult(
+                    incompleteResult.childId(),
+                    incompleteResult.academyScheduleId(),
+                    incompleteResult.startTime(),
+                    incompleteResult.endTime(),
+                    lesson.lessonId(),
+                    lesson.academyName(),
+                    lesson.lessonName()
+            );
+        }
     }
 
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/CalendarFindSchedulesByDateResults.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/dto/result/CalendarFindSchedulesByDateResults.java
@@ -1,0 +1,15 @@
+package org.guzzing.studayserver.domain.calendar.service.dto.result;
+
+import java.util.List;
+
+public record CalendarFindSchedulesByDateResults(
+        List<CalendarFindSchedulesByDateResult> results
+) {
+
+    public record CalendarFindSchedulesByDateResult(
+
+    ) {
+
+    }
+
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
@@ -1,0 +1,38 @@
+package org.guzzing.studayserver.domain.calendarInfo.controller;
+
+import jakarta.validation.Valid;
+import java.util.ArrayList;
+import org.guzzing.studayserver.domain.auth.memberId.MemberId;
+import org.guzzing.studayserver.domain.calendarInfo.controller.request.CalendarMonthMarkRequest;
+import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarMonthMarkResponse;
+import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarMonthMarkResponse.DateRange;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/calendar")
+public class CalendarRestController {
+
+    @GetMapping(
+            path = "/mark",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<CalendarMonthMarkResponse> getMonthMark(
+            @MemberId Long memberId,
+            @RequestParam @Valid CalendarMonthMarkRequest calendarMonthMarkRequest
+    ) {
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new CalendarMonthMarkResponse(
+                        new DateRange(1, 31),
+                        new ArrayList<>(),
+                        new ArrayList<>()
+                ));
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
@@ -28,12 +28,12 @@ public class CalendarRestController {
             path = "/mark",
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<CalendarYearMonthMarkResponse> getYearMonthMark(
+    public ResponseEntity<CalendarYearMonthMarkResponse> findYearMonthMark(
             @MemberId Long memberId,
             @RequestParam @Valid CalendarYearMonthMarkRequest request
     ) {
 
-        CalendarYearMonthMarkResult result = calendarFacade.getYearMonthMark(request.toParam(memberId));
+        CalendarYearMonthMarkResult result = calendarFacade.findYearMonthMark(request.toParam(memberId));
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(CalendarYearMonthMarkResponse.from(result));

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
@@ -3,9 +3,10 @@ package org.guzzing.studayserver.domain.calendarInfo.controller;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import org.guzzing.studayserver.domain.auth.memberId.MemberId;
-import org.guzzing.studayserver.domain.calendarInfo.controller.request.CalendarMonthMarkRequest;
-import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarMonthMarkResponse;
-import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarMonthMarkResponse.DateRange;
+import org.guzzing.studayserver.domain.calendarInfo.controller.request.CalendarYearMonthMarkRequest;
+import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarYearMonthMarkResponse;
+import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarYearMonthMarkResponse.DateRange;
+import org.guzzing.studayserver.domain.calendarInfo.service.CalendarFacade;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -18,18 +19,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/calendar")
 public class CalendarRestController {
 
+    private CalendarFacade calendarFacade;
+
+    public CalendarRestController(CalendarFacade calendarFacade) {
+        this.calendarFacade = calendarFacade;
+    }
+
     @GetMapping(
             path = "/mark",
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<CalendarMonthMarkResponse> getMonthMark(
+    public ResponseEntity<CalendarYearMonthMarkResponse> getYearMonthMark(
             @MemberId Long memberId,
-            @RequestParam @Valid CalendarMonthMarkRequest calendarMonthMarkRequest
+            @RequestParam @Valid CalendarYearMonthMarkRequest request
     ) {
 
+        CalendarMonthMarkResult result = calendarFacade.getYearMonthMark(request.toParam(memberId));
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(new CalendarMonthMarkResponse(
+                .body(new CalendarYearMonthMarkResponse(
                         new DateRange(1, 31),
                         new ArrayList<>(),
                         new ArrayList<>()

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
@@ -7,6 +7,7 @@ import org.guzzing.studayserver.domain.calendarInfo.controller.request.CalendarY
 import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarYearMonthMarkResponse;
 import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarYearMonthMarkResponse.DateRange;
 import org.guzzing.studayserver.domain.calendarInfo.service.CalendarFacade;
+import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -34,7 +35,7 @@ public class CalendarRestController {
             @RequestParam @Valid CalendarYearMonthMarkRequest request
     ) {
 
-        CalendarMonthMarkResult result = calendarFacade.getYearMonthMark(request.toParam(memberId));
+        CalendarYearMonthMarkResult result = calendarFacade.getYearMonthMark(request.toParam(memberId));
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new CalendarYearMonthMarkResponse(

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
@@ -57,9 +57,9 @@ public class CalendarRestController {
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(new CalendarFindSchedulesByDateResponses(
+                .body(CalendarFindSchedulesByDateResponses.from(
                         date,
-                        new ArrayList<>()
+                        results
                 ));
     }
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
@@ -1,11 +1,9 @@
 package org.guzzing.studayserver.domain.calendarInfo.controller;
 
 import jakarta.validation.Valid;
-import java.util.ArrayList;
 import org.guzzing.studayserver.domain.auth.memberId.MemberId;
 import org.guzzing.studayserver.domain.calendarInfo.controller.request.CalendarYearMonthMarkRequest;
 import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarYearMonthMarkResponse;
-import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarYearMonthMarkResponse.DateRange;
 import org.guzzing.studayserver.domain.calendarInfo.service.CalendarFacade;
 import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult;
 import org.springframework.http.HttpStatus;
@@ -38,10 +36,6 @@ public class CalendarRestController {
         CalendarYearMonthMarkResult result = calendarFacade.getYearMonthMark(request.toParam(memberId));
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(new CalendarYearMonthMarkResponse(
-                        new DateRange(1, 31),
-                        new ArrayList<>(),
-                        new ArrayList<>()
-                ));
+                .body(CalendarYearMonthMarkResponse.from(result));
     }
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import org.guzzing.studayserver.domain.auth.memberId.MemberId;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.CalendarFindSchedulesByDateResults;
 import org.guzzing.studayserver.domain.calendarInfo.controller.request.CalendarYearMonthMarkRequest;
 import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarFindSchedulesByDateResponses;
 import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarYearMonthMarkResponse;
@@ -23,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/calendar")
 public class CalendarRestController {
 
-    private CalendarFacade calendarFacade;
+    private final CalendarFacade calendarFacade;
 
     public CalendarRestController(CalendarFacade calendarFacade) {
         this.calendarFacade = calendarFacade;
@@ -52,6 +53,7 @@ public class CalendarRestController {
             @MemberId Long memberId,
             @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate date
     ) {
+        CalendarFindSchedulesByDateResults results = calendarFacade.findSchedulesByDate(memberId, date);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/CalendarRestController.java
@@ -1,11 +1,16 @@
 package org.guzzing.studayserver.domain.calendarInfo.controller;
 
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import org.guzzing.studayserver.domain.auth.memberId.MemberId;
 import org.guzzing.studayserver.domain.calendarInfo.controller.request.CalendarYearMonthMarkRequest;
+import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarFindSchedulesByDateResponses;
 import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarYearMonthMarkResponse;
 import org.guzzing.studayserver.domain.calendarInfo.service.CalendarFacade;
 import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -37,5 +42,22 @@ public class CalendarRestController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(CalendarYearMonthMarkResponse.from(result));
+    }
+
+    @GetMapping(
+            path = "/date",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<CalendarFindSchedulesByDateResponses> findSchedulesByDate(
+            @MemberId Long memberId,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate date
+    ) {
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new CalendarFindSchedulesByDateResponses(
+                        date,
+                        new ArrayList<>()
+                ));
     }
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/request/CalendarMonthMarkRequest.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/request/CalendarMonthMarkRequest.java
@@ -1,0 +1,17 @@
+package org.guzzing.studayserver.domain.calendarInfo.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Range;
+
+public record CalendarMonthMarkRequest(
+        @Range(min = 2000, max = 2100)
+        @NotNull
+        Integer year,
+
+        @Range(min = 1, max = 12)
+        @NotNull
+        Integer month
+) {
+
+
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/request/CalendarYearMonthMarkRequest.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/request/CalendarYearMonthMarkRequest.java
@@ -1,6 +1,7 @@
 package org.guzzing.studayserver.domain.calendarInfo.controller.request;
 
 import jakarta.validation.constraints.NotNull;
+import org.guzzing.studayserver.domain.calendarInfo.service.param.CalendarYearMonthMarkParam;
 import org.hibernate.validator.constraints.Range;
 
 public record CalendarYearMonthMarkRequest(
@@ -14,4 +15,11 @@ public record CalendarYearMonthMarkRequest(
 ) {
 
 
+    public CalendarYearMonthMarkParam toParam(Long memberId) {
+        return new CalendarYearMonthMarkParam(
+                memberId,
+                year,
+                month
+        );
+    }
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/request/CalendarYearMonthMarkRequest.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/request/CalendarYearMonthMarkRequest.java
@@ -3,7 +3,7 @@ package org.guzzing.studayserver.domain.calendarInfo.controller.request;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Range;
 
-public record CalendarMonthMarkRequest(
+public record CalendarYearMonthMarkRequest(
         @Range(min = 2000, max = 2100)
         @NotNull
         Integer year,

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarFindSchedulesByDateResponses.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarFindSchedulesByDateResponses.java
@@ -1,0 +1,32 @@
+package org.guzzing.studayserver.domain.calendarInfo.controller.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CalendarFindSchedulesByDateResponses(
+        LocalDate date,
+        List<CalendarFindSchedulesByDateResponse> dateResponses
+) {
+
+    public record CalendarFindSchedulesByDateResponse(
+            String startTime,
+            List<SameStartTimeScheduleResponse> schedules
+    ) {
+
+    }
+
+    public record SameStartTimeScheduleResponse(
+            String academyName,
+            String endTIme,
+            List<OverlappingScheduleResponse> overlappingSchedules
+    ) {
+
+    }
+
+    public record OverlappingScheduleResponse(
+            long scheduleId,
+            boolean isRepeatable
+    ) {
+
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarFindSchedulesByDateResponses.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarFindSchedulesByDateResponses.java
@@ -1,23 +1,81 @@
 package org.guzzing.studayserver.domain.calendarInfo.controller.response;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.CalendarFindSchedulesByDateResults;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.CalendarFindSchedulesByDateResults.CalendarFindSchedulesByDateResult;
 
 public record CalendarFindSchedulesByDateResponses(
         LocalDate date,
         List<CalendarFindSchedulesByDateResponse> dateResponses
 ) {
 
+    public static CalendarFindSchedulesByDateResponses from(
+            LocalDate date, CalendarFindSchedulesByDateResults results) {
+        Map<LocalTime, List<CalendarFindSchedulesByDateResult>> schedulesGroupedByStartTime =
+                results.results().stream()
+                        .collect(Collectors.groupingBy(CalendarFindSchedulesByDateResult::startTime));
+
+        List<CalendarFindSchedulesByDateResponse> dateResponses = new ArrayList<>();
+        for (LocalTime startTime : schedulesGroupedByStartTime.keySet()) {
+            Map<String, List<CalendarFindSchedulesByDateResult>> schedulesGroupedByAcademyAndEndTime =
+                    schedulesGroupedByStartTime.get(startTime).stream()
+                            .collect(Collectors.groupingBy(
+                                    result -> result.lessonId() + "_"
+                                            + result.academyName() + "_"
+                                            + result.lessonName() + "_"
+                                            + result.endTime()));
+
+            List<SameStartTimeScheduleResponse> sameStartTimeSchedules = new ArrayList<>();
+            for (Map.Entry<String, List<CalendarFindSchedulesByDateResult>> entry : schedulesGroupedByAcademyAndEndTime.entrySet()) {
+                String key = entry.getKey();
+                String[] parts = key.split("_");
+                Long lessonId = Long.parseLong(parts[0]);
+                String academyName = parts[1];
+                String lessonName = parts[2];
+                LocalTime endTime = LocalTime.parse(parts[3]);
+
+                List<OverlappingScheduleResponse> overlappingResponses = new ArrayList<>();
+                for (CalendarFindSchedulesByDateResult result : entry.getValue()) {
+                    overlappingResponses.add(new OverlappingScheduleResponse(
+                            result.academyScheduleId(),
+                            true
+                    ));
+                }
+
+                sameStartTimeSchedules.add(new SameStartTimeScheduleResponse(
+                        lessonId,
+                        academyName,
+                        lessonName,
+                        endTime,
+                        overlappingResponses
+                ));
+            }
+            dateResponses.add(new CalendarFindSchedulesByDateResponse(startTime, sameStartTimeSchedules));
+        }
+
+        return new CalendarFindSchedulesByDateResponses(
+                date,
+                dateResponses
+        );
+    }
+
     public record CalendarFindSchedulesByDateResponse(
-            String startTime,
+            LocalTime startTime,
             List<SameStartTimeScheduleResponse> schedules
     ) {
 
     }
 
     public record SameStartTimeScheduleResponse(
+            Long lessonId,
             String academyName,
-            String endTIme,
+            String lessonName,
+            LocalTime endTIme,
             List<OverlappingScheduleResponse> overlappingSchedules
     ) {
 

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarMonthMarkResponse.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarMonthMarkResponse.java
@@ -1,0 +1,34 @@
+package org.guzzing.studayserver.domain.calendarInfo.controller.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CalendarMonthMarkResponse(
+        DateRange dateRange,
+        List<Holiday> holidays,
+        List<Integer> existenceDays
+) {
+
+    public record DateRange(
+            int firstDay,
+            int lastDay
+    ) {
+
+    }
+
+    public record Holiday(
+            LocalDate date,
+            List<String> names
+    ) {
+
+        public Holiday {
+            validateNames(names);
+        }
+
+        private void validateNames(List<String> names) {
+            if (names.isEmpty()) {
+                throw new IllegalStateException("공휴일의 이름이 없습니다.");
+            }
+        }
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarYearMonthMarkResponse.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarYearMonthMarkResponse.java
@@ -3,7 +3,7 @@ package org.guzzing.studayserver.domain.calendarInfo.controller.response;
 import java.time.LocalDate;
 import java.util.List;
 
-public record CalendarMonthMarkResponse(
+public record CalendarYearMonthMarkResponse(
         DateRange dateRange,
         List<Holiday> holidays,
         List<Integer> existenceDays

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarYearMonthMarkResponse.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarYearMonthMarkResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public record CalendarYearMonthMarkResponse(
         DateRange dateRange,
-        List<Holiday> holidays,
+        List<HolidayResponse> holidayResponses,
         List<Integer> existenceDays
 ) {
 
@@ -16,12 +16,12 @@ public record CalendarYearMonthMarkResponse(
 
     }
 
-    public record Holiday(
+    public record HolidayResponse(
             LocalDate date,
             List<String> names
     ) {
 
-        public Holiday {
+        public HolidayResponse {
             validateNames(names);
         }
 

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarYearMonthMarkResponse.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarYearMonthMarkResponse.java
@@ -1,19 +1,33 @@
 package org.guzzing.studayserver.domain.calendarInfo.controller.response;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
+import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult;
+import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult.HolidayResult;
 
 public record CalendarYearMonthMarkResponse(
-        DateRange dateRange,
-        List<HolidayResponse> holidayResponses,
+        int lastDay,
+        List<HolidayResponse> holidays,
         List<Integer> existenceDays
 ) {
 
-    public record DateRange(
-            int firstDay,
-            int lastDay
-    ) {
+    public static CalendarYearMonthMarkResponse from(CalendarYearMonthMarkResult result) {
+        List<HolidayResponse> holidayResponses = result.holidayResults().stream()
+                .sorted(Comparator.comparing(HolidayResult::date))
+                .map(r -> new HolidayResponse(r.date(), r.names()))
+                .toList();
 
+        List<Integer> existenceDays = result.existenceDays().stream()
+                .sorted()
+                .map(LocalDate::getDayOfMonth)
+                .toList();
+
+        return new CalendarYearMonthMarkResponse(
+                result.lastDayOfMonth(),
+                holidayResponses,
+                existenceDays
+        );
     }
 
     public record HolidayResponse(

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
@@ -1,44 +1,39 @@
 package org.guzzing.studayserver.domain.calendarInfo.service;
 
-import java.util.List;
-import org.guzzing.studayserver.domain.calendar.service.AcademyCalendarAccessService;
 import org.guzzing.studayserver.domain.calendarInfo.service.param.CalendarYearMonthMarkParam;
 import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult;
 import org.guzzing.studayserver.domain.calendarInfo.service.util.DateUtility;
+import org.guzzing.studayserver.domain.holiday.service.HolidayService;
+import org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult;
 import org.guzzing.studayserver.domain.member.service.MemberService;
-import org.guzzing.studayserver.domain.member.service.result.MemberInformationResult;
-import org.guzzing.studayserver.domain.member.service.result.MemberInformationResult.MemberChildInformationResult;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CalendarFacade {
 
-    private final DateUtility dateUtility;
     private final MemberService memberService;
-//    private final HolidayService holidayService;
+    private final HolidayService holidayService;
 //    private final AcademyCalendarAccessService academyCalendarAccessService;
 
     public CalendarFacade(
-            DateUtility dateUtility,
-            MemberService memberService
-//            HolidayService holidayService,
+            MemberService memberService,
+            HolidayService holidayService
 //            AcademyCalendarAccessService academyCalendarAccessService
     ) {
-        this.dateUtility = dateUtility;
         this.memberService = memberService;
-//        this.holidayService = holidayService;
+        this.holidayService = holidayService;
 //        this.academyCalendarAccessService = academyCalendarAccessService;
     }
 
     @Transactional(readOnly = true)
     public CalendarYearMonthMarkResult getYearMonthMark(CalendarYearMonthMarkParam calendarMonthMarkParam) {
-        int lastDayOfMonth = dateUtility.getLastDayOfMonth(
+        int lastDayOfMonth = DateUtility.getLastDayOfMonth(
                 calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
 
-//        HolidayFindByYearMonthResult holidayFindByYearMonthResult = holidayService.findByYearMonth(
-//                calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
-//
+        HolidayFindByYearMonthResult holidayFindByYearMonthResult = holidayService.findByYearMonth(
+                calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
+
 //        MemberInformationResult memberInformationResult = memberService.getById(calendarMonthMarkParam.memberId());
 //        List<Long> childIds = memberInformationResult.memberChildInformationResults().stream()
 //                .map(MemberChildInformationResult::childId)
@@ -48,8 +43,8 @@ public class CalendarFacade {
 //                childIds, calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
 
         return CalendarYearMonthMarkResult.of(
-                lastDayOfMonth
-//                holidayFindByYearMonthResult,
+                lastDayOfMonth,
+                holidayFindByYearMonthResult
 //                academyCalendarChildrenScheduleResult
         );
     }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
@@ -32,7 +32,7 @@ public class CalendarFacade {
     }
 
     @Transactional(readOnly = true)
-    public CalendarYearMonthMarkResult getYearMonthMark(CalendarYearMonthMarkParam calendarMonthMarkParam) {
+    public CalendarYearMonthMarkResult findYearMonthMark(CalendarYearMonthMarkParam calendarMonthMarkParam) {
         int lastDayOfMonth = DateUtility.getLastDayOfMonth(
                 calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
 

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
@@ -1,8 +1,12 @@
 package org.guzzing.studayserver.domain.calendarInfo.service;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import org.guzzing.studayserver.domain.calendar.service.AcademySchedulesReadService;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleFindByDateResults;
 import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleYearMonthResults;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.CalendarFindSchedulesByDateResults;
 import org.guzzing.studayserver.domain.calendarInfo.service.param.CalendarYearMonthMarkParam;
 import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult;
 import org.guzzing.studayserver.domain.calendarInfo.service.util.DateUtility;
@@ -52,5 +56,19 @@ public class CalendarFacade {
                 holidayFindByYearMonthResult,
                 academyScheduleYearMonthResults
         );
+    }
+
+    @Transactional(readOnly = true)
+    public CalendarFindSchedulesByDateResults findSchedulesByDate(Long memberId, LocalDate date) {
+        MemberInformationResult memberInformationResult = memberService.getById(memberId);
+
+        List<Long> childIds = memberInformationResult.memberChildInformationResults().stream()
+                .map(MemberChildInformationResult::childId)
+                .toList();
+        AcademyScheduleFindByDateResults academyScheduleFindByDateResults = academySchedulesReadService.findByDate(
+                childIds, date);
+
+
+        return new CalendarFindSchedulesByDateResults(new ArrayList<>());
     }
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
@@ -3,16 +3,22 @@ package org.guzzing.studayserver.domain.calendarInfo.service;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.guzzing.studayserver.domain.academy.service.LessonReadService;
+import org.guzzing.studayserver.domain.academy.service.dto.result.LessonFindByIdsResults;
 import org.guzzing.studayserver.domain.calendar.service.AcademySchedulesReadService;
 import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleFindByDateResults;
 import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleFindByDateResults.AcademyScheduleFindByDateResult;
 import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleYearMonthResults;
 import org.guzzing.studayserver.domain.calendar.service.dto.result.CalendarFindSchedulesByDateResults;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.CalendarFindSchedulesByDateResults.CalendarFindSchedulesByDateResult;
 import org.guzzing.studayserver.domain.calendarInfo.service.param.CalendarYearMonthMarkParam;
 import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult;
+import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarFindSchedulesByDateIncompleteResult;
 import org.guzzing.studayserver.domain.calendarInfo.service.util.DateUtility;
 import org.guzzing.studayserver.domain.dashboard.service.DashboardReadService;
 import org.guzzing.studayserver.domain.dashboard.service.dto.response.DashBoardFindByIdsResults;
+import org.guzzing.studayserver.domain.dashboard.service.dto.response.DashBoardFindByIdsResults.DashBoardFindByIdsResult;
 import org.guzzing.studayserver.domain.holiday.service.HolidayService;
 import org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult;
 import org.guzzing.studayserver.domain.member.service.MemberService;
@@ -28,13 +34,16 @@ public class CalendarFacade {
     private final HolidayService holidayService;
     private final DashboardReadService dashboardReadService;
     private final AcademySchedulesReadService academySchedulesReadService;
+    private final LessonReadService lessonReadService;
 
     public CalendarFacade(MemberService memberService, HolidayService holidayService,
-            DashboardReadService dashboardReadService, AcademySchedulesReadService academySchedulesReadService) {
+            DashboardReadService dashboardReadService, AcademySchedulesReadService academySchedulesReadService,
+            LessonReadService lessonReadService) {
         this.memberService = memberService;
         this.holidayService = holidayService;
         this.dashboardReadService = dashboardReadService;
         this.academySchedulesReadService = academySchedulesReadService;
+        this.lessonReadService = lessonReadService;
     }
 
     @Transactional(readOnly = true)
@@ -74,6 +83,11 @@ public class CalendarFacade {
                 .map(AcademyScheduleFindByDateResult::dashboardId)
                 .toList();
         DashBoardFindByIdsResults dashBoardFindByIdsResults = dashboardReadService.findByIds(dashboardIds);
+
+        List<Long> lessonIds = dashBoardFindByIdsResults.dashBoards().stream()
+                .map(DashBoardFindByIdsResult::lessonId)
+                .toList();
+        LessonFindByIdsResults lessonFindByIdsResults = lessonReadService.findByIds(lessonIds);
 
         return new CalendarFindSchedulesByDateResults(new ArrayList<>());
     }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
@@ -2,6 +2,9 @@ package org.guzzing.studayserver.domain.calendarInfo.service;
 
 import java.util.List;
 import org.guzzing.studayserver.domain.calendar.service.AcademyCalendarAccessService;
+import org.guzzing.studayserver.domain.calendarInfo.service.param.CalendarYearMonthMarkParam;
+import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult;
+import org.guzzing.studayserver.domain.calendarInfo.service.util.DateUtility;
 import org.guzzing.studayserver.domain.member.service.MemberService;
 import org.guzzing.studayserver.domain.member.service.result.MemberInformationResult;
 import org.guzzing.studayserver.domain.member.service.result.MemberInformationResult.MemberChildInformationResult;
@@ -12,16 +15,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class CalendarFacade {
 
     private final DateUtility dateUtility;
-    private final HolidayService holidayService;
     private final MemberService memberService;
-    private final AcademyCalendarAccessService academyCalendarAccessService;
+//    private final HolidayService holidayService;
+//    private final AcademyCalendarAccessService academyCalendarAccessService;
 
-    public CalendarFacade(DateUtility dateUtility, HolidayService holidayService, MemberService memberService,
-            AcademyCalendarAccessService academyCalendarAccessService) {
+    public CalendarFacade(
+            DateUtility dateUtility,
+            MemberService memberService
+//            HolidayService holidayService,
+//            AcademyCalendarAccessService academyCalendarAccessService
+    ) {
         this.dateUtility = dateUtility;
-        this.holidayService = holidayService;
         this.memberService = memberService;
-        this.academyCalendarAccessService = academyCalendarAccessService;
+//        this.holidayService = holidayService;
+//        this.academyCalendarAccessService = academyCalendarAccessService;
     }
 
     @Transactional(readOnly = true)
@@ -29,21 +36,21 @@ public class CalendarFacade {
         int lastDayOfMonth = dateUtility.getLastDayOfMonth(
                 calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
 
-        HolidayFindByYearMonthResult holidayFindByYearMonthResult = holidayService.findByYearMonth(
-                calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
-
-        MemberInformationResult memberInformationResult = memberService.getById(calendarMonthMarkParam.memberId());
-        List<Long> childIds = memberInformationResult.memberChildInformationResults().stream()
-                .map(MemberChildInformationResult::childId)
-                .toList();
-
-        AcademyCalendarChildrenScheduleResult academyCalendarChildrenScheduleResult = academyCalendarAccessService.getChildrenScheduleByYearMonth(
-                childIds, calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
+//        HolidayFindByYearMonthResult holidayFindByYearMonthResult = holidayService.findByYearMonth(
+//                calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
+//
+//        MemberInformationResult memberInformationResult = memberService.getById(calendarMonthMarkParam.memberId());
+//        List<Long> childIds = memberInformationResult.memberChildInformationResults().stream()
+//                .map(MemberChildInformationResult::childId)
+//                .toList();
+//
+//        AcademyCalendarChildrenScheduleResult academyCalendarChildrenScheduleResult = academyCalendarAccessService.getChildrenScheduleByYearMonth(
+//                childIds, calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
 
         return CalendarYearMonthMarkResult.of(
-                lastDayOfMonth,
-                holidayFindByYearMonthResult,
-                academyCalendarChildrenScheduleResult
+                lastDayOfMonth
+//                holidayFindByYearMonthResult,
+//                academyCalendarChildrenScheduleResult
         );
     }
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
@@ -1,11 +1,16 @@
 package org.guzzing.studayserver.domain.calendarInfo.service;
 
+import java.util.List;
+import org.guzzing.studayserver.domain.calendar.service.AcademySchedulesReadService;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleYearMonthResults;
 import org.guzzing.studayserver.domain.calendarInfo.service.param.CalendarYearMonthMarkParam;
 import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult;
 import org.guzzing.studayserver.domain.calendarInfo.service.util.DateUtility;
 import org.guzzing.studayserver.domain.holiday.service.HolidayService;
 import org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult;
 import org.guzzing.studayserver.domain.member.service.MemberService;
+import org.guzzing.studayserver.domain.member.service.result.MemberInformationResult;
+import org.guzzing.studayserver.domain.member.service.result.MemberInformationResult.MemberChildInformationResult;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,16 +19,16 @@ public class CalendarFacade {
 
     private final MemberService memberService;
     private final HolidayService holidayService;
-//    private final AcademyCalendarAccessService academyCalendarAccessService;
+    private final AcademySchedulesReadService academySchedulesReadService;
 
     public CalendarFacade(
             MemberService memberService,
-            HolidayService holidayService
-//            AcademyCalendarAccessService academyCalendarAccessService
+            HolidayService holidayService,
+            AcademySchedulesReadService academySchedulesReadService
     ) {
         this.memberService = memberService;
         this.holidayService = holidayService;
-//        this.academyCalendarAccessService = academyCalendarAccessService;
+        this.academySchedulesReadService = academySchedulesReadService;
     }
 
     @Transactional(readOnly = true)
@@ -34,18 +39,18 @@ public class CalendarFacade {
         HolidayFindByYearMonthResult holidayFindByYearMonthResult = holidayService.findByYearMonth(
                 calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
 
-//        MemberInformationResult memberInformationResult = memberService.getById(calendarMonthMarkParam.memberId());
-//        List<Long> childIds = memberInformationResult.memberChildInformationResults().stream()
-//                .map(MemberChildInformationResult::childId)
-//                .toList();
-//
-//        AcademyCalendarChildrenScheduleResult academyCalendarChildrenScheduleResult = academyCalendarAccessService.getChildrenScheduleByYearMonth(
-//                childIds, calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
+        MemberInformationResult memberInformationResult = memberService.getById(calendarMonthMarkParam.memberId());
+        List<Long> childIds = memberInformationResult.memberChildInformationResults().stream()
+                .map(MemberChildInformationResult::childId)
+                .toList();
+
+        AcademyScheduleYearMonthResults academyScheduleYearMonthResults = academySchedulesReadService.getScheduleByYearMonth(
+                childIds, calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
 
         return CalendarYearMonthMarkResult.of(
                 lastDayOfMonth,
-                holidayFindByYearMonthResult
-//                academyCalendarChildrenScheduleResult
+                holidayFindByYearMonthResult,
+                academyScheduleYearMonthResults
         );
     }
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
@@ -1,0 +1,49 @@
+package org.guzzing.studayserver.domain.calendarInfo.service;
+
+import java.util.List;
+import org.guzzing.studayserver.domain.calendar.service.AcademyCalendarAccessService;
+import org.guzzing.studayserver.domain.member.service.MemberService;
+import org.guzzing.studayserver.domain.member.service.result.MemberInformationResult;
+import org.guzzing.studayserver.domain.member.service.result.MemberInformationResult.MemberChildInformationResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CalendarFacade {
+
+    private final DateUtility dateUtility;
+    private final HolidayService holidayService;
+    private final MemberService memberService;
+    private final AcademyCalendarAccessService academyCalendarAccessService;
+
+    public CalendarFacade(DateUtility dateUtility, HolidayService holidayService, MemberService memberService,
+            AcademyCalendarAccessService academyCalendarAccessService) {
+        this.dateUtility = dateUtility;
+        this.holidayService = holidayService;
+        this.memberService = memberService;
+        this.academyCalendarAccessService = academyCalendarAccessService;
+    }
+
+    @Transactional(readOnly = true)
+    public CalendarYearMonthMarkResult getYearMonthMark(CalendarYearMonthMarkParam calendarMonthMarkParam) {
+        int lastDayOfMonth = dateUtility.getLastDayOfMonth(
+                calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
+
+        HolidayFindByYearMonthResult holidayFindByYearMonthResult = holidayService.findByYearMonth(
+                calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
+
+        MemberInformationResult memberInformationResult = memberService.getById(calendarMonthMarkParam.memberId());
+        List<Long> childIds = memberInformationResult.memberChildInformationResults().stream()
+                .map(MemberChildInformationResult::childId)
+                .toList();
+
+        AcademyCalendarChildrenScheduleResult academyCalendarChildrenScheduleResult = academyCalendarAccessService.getChildrenScheduleByYearMonth(
+                childIds, calendarMonthMarkParam.year(), calendarMonthMarkParam.month());
+
+        return CalendarYearMonthMarkResult.of(
+                lastDayOfMonth,
+                holidayFindByYearMonthResult,
+                academyCalendarChildrenScheduleResult
+        );
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacade.java
@@ -89,6 +89,18 @@ public class CalendarFacade {
                 .toList();
         LessonFindByIdsResults lessonFindByIdsResults = lessonReadService.findByIds(lessonIds);
 
-        return new CalendarFindSchedulesByDateResults(new ArrayList<>());
+        List<CalendarFindSchedulesByDateIncompleteResult> combinedResults = academyScheduleFindByDateResults.academySchedules().stream()
+                .flatMap(schedule -> dashBoardFindByIdsResults.dashBoards().stream()
+                        .filter(dashboard -> dashboard.dashboardId().equals(schedule.dashboardId()))
+                        .map(dashboard -> CalendarFindSchedulesByDateIncompleteResult.of(schedule, dashboard)))
+                .toList();
+
+        List<CalendarFindSchedulesByDateResult> finalResults = combinedResults.stream()
+                .flatMap(incompleteResult -> lessonFindByIdsResults.lessons().stream()
+                        .filter(lesson -> lesson.lessonId().equals(incompleteResult.lessonId()))
+                        .map(lesson -> CalendarFindSchedulesByDateResult.of(incompleteResult, lesson)))
+                .toList();
+
+        return new CalendarFindSchedulesByDateResults(finalResults);
     }
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/param/CalendarYearMonthMarkParam.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/param/CalendarYearMonthMarkParam.java
@@ -1,0 +1,9 @@
+package org.guzzing.studayserver.domain.calendarInfo.service.param;
+
+public record CalendarYearMonthMarkParam(
+        long memberId,
+        int year,
+        int month
+) {
+
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/result/CalendarFindSchedulesByDateIncompleteResult.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/result/CalendarFindSchedulesByDateIncompleteResult.java
@@ -1,0 +1,25 @@
+package org.guzzing.studayserver.domain.calendarInfo.service.result;
+
+import java.time.LocalTime;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleFindByDateResults.AcademyScheduleFindByDateResult;
+import org.guzzing.studayserver.domain.dashboard.service.dto.response.DashBoardFindByIdsResults.DashBoardFindByIdsResult;
+
+public record CalendarFindSchedulesByDateIncompleteResult(
+        Long childId,
+        Long academyScheduleId,
+        LocalTime startTime,
+        LocalTime endTime,
+        Long lessonId
+) {
+
+    public static CalendarFindSchedulesByDateIncompleteResult of(
+            AcademyScheduleFindByDateResult schedule, DashBoardFindByIdsResult dashboard) {
+        return new CalendarFindSchedulesByDateIncompleteResult(
+                schedule.childId(),
+                schedule.academyScheduleId(),
+                schedule.startTime(),
+                schedule.endTime(),
+                dashboard.lessonId()
+        );
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/result/CalendarYearMonthMarkResult.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/result/CalendarYearMonthMarkResult.java
@@ -2,22 +2,33 @@ package org.guzzing.studayserver.domain.calendarInfo.service.result;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleYearMonthResults;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleYearMonthResults.AcademyScheduleYearMonthResult;
 import org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult;
 
 public record CalendarYearMonthMarkResult(
         int lastDayOfMonth,
-        List<HolidayResult> holidayResults
+        List<HolidayResult> holidayResults,
+        List<LocalDate> existenceDays
 ) {
 
     public static CalendarYearMonthMarkResult of(int lastDayOfMonth,
-            HolidayFindByYearMonthResult holidayFindByYearMonthResult) {
+            HolidayFindByYearMonthResult holidayFindByYearMonthResult,
+            AcademyScheduleYearMonthResults academyScheduleYearMonthResults) {
         List<HolidayResult> holidayResults = holidayFindByYearMonthResult.holidayResults().stream()
                 .map(r -> new HolidayResult(r.date(), r.names()))
                 .toList();
 
+        Set<LocalDate> existenceDays = academyScheduleYearMonthResults.academyScheduleYearMonthResults().stream()
+                .collect(Collectors.groupingBy(AcademyScheduleYearMonthResult::scheduleDate))
+                .keySet();
+
         return new CalendarYearMonthMarkResult(
                 lastDayOfMonth,
-                holidayResults
+                holidayResults,
+                existenceDays.stream().toList()
         );
     }
 
@@ -27,4 +38,5 @@ public record CalendarYearMonthMarkResult(
     ) {
 
     }
+
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/result/CalendarYearMonthMarkResult.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/result/CalendarYearMonthMarkResult.java
@@ -1,0 +1,10 @@
+package org.guzzing.studayserver.domain.calendarInfo.service.result;
+
+public record CalendarYearMonthMarkResult(
+        int lastDayOfMonth
+) {
+
+    public static CalendarYearMonthMarkResult of(int lastDayOfMonth) {
+        return new CalendarYearMonthMarkResult(lastDayOfMonth);
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/result/CalendarYearMonthMarkResult.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/result/CalendarYearMonthMarkResult.java
@@ -1,10 +1,30 @@
 package org.guzzing.studayserver.domain.calendarInfo.service.result;
 
+import java.time.LocalDate;
+import java.util.List;
+import org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult;
+
 public record CalendarYearMonthMarkResult(
-        int lastDayOfMonth
+        int lastDayOfMonth,
+        List<HolidayResult> holidayResults
 ) {
 
-    public static CalendarYearMonthMarkResult of(int lastDayOfMonth) {
-        return new CalendarYearMonthMarkResult(lastDayOfMonth);
+    public static CalendarYearMonthMarkResult of(int lastDayOfMonth,
+            HolidayFindByYearMonthResult holidayFindByYearMonthResult) {
+        List<HolidayResult> holidayResults = holidayFindByYearMonthResult.holidayResults().stream()
+                .map(r -> new HolidayResult(r.date(), r.names()))
+                .toList();
+
+        return new CalendarYearMonthMarkResult(
+                lastDayOfMonth,
+                holidayResults
+        );
+    }
+
+    public record HolidayResult(
+            LocalDate date,
+            List<String> names
+    ) {
+
     }
 }

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/util/DateUtility.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/util/DateUtility.java
@@ -1,9 +1,7 @@
 package org.guzzing.studayserver.domain.calendarInfo.service.util;
 
 import java.time.YearMonth;
-import org.springframework.stereotype.Component;
 
-@Component
 public class DateUtility {
 
     public static int getLastDayOfMonth(int year, int month) {

--- a/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/util/DateUtility.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendarInfo/service/util/DateUtility.java
@@ -1,0 +1,13 @@
+package org.guzzing.studayserver.domain.calendarInfo.service.util;
+
+import java.time.YearMonth;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DateUtility {
+
+    public static int getLastDayOfMonth(int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        return yearMonth.lengthOfMonth();
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/dashboard/repository/DashboardJpaRepository.java
+++ b/src/main/java/org/guzzing/studayserver/domain/dashboard/repository/DashboardJpaRepository.java
@@ -1,9 +1,15 @@
 package org.guzzing.studayserver.domain.dashboard.repository;
 
+import java.util.List;
 import org.guzzing.studayserver.domain.dashboard.model.Dashboard;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DashboardJpaRepository extends
         JpaRepository<Dashboard, Long>, DashboardRepository, DashboardQuerydslRepository {
 
+    @Query("SELECT dab FROM Dashboard AS dab "
+            + "JOIN FETCH dab.dashboardSchedules dabschs "
+            + "WHERE dab.id IN :dashboardIds")
+    List<Dashboard> findByIds(List<Long> dashboardIds);
 }

--- a/src/main/java/org/guzzing/studayserver/domain/dashboard/repository/DashboardRepository.java
+++ b/src/main/java/org/guzzing/studayserver/domain/dashboard/repository/DashboardRepository.java
@@ -22,4 +22,5 @@ public interface DashboardRepository {
 
     List<Dashboard> findAll();
 
+    List<Dashboard> findByIds(List<Long> dashboardIds);
 }

--- a/src/main/java/org/guzzing/studayserver/domain/dashboard/service/DashboardReadService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/dashboard/service/DashboardReadService.java
@@ -1,0 +1,32 @@
+package org.guzzing.studayserver.domain.dashboard.service;
+
+import java.util.List;
+import org.guzzing.studayserver.domain.dashboard.model.Dashboard;
+import org.guzzing.studayserver.domain.dashboard.repository.DashboardRepository;
+import org.guzzing.studayserver.domain.dashboard.service.dto.response.DashBoardFindByIdsResults;
+import org.guzzing.studayserver.domain.dashboard.service.dto.response.DashBoardFindByIdsResults.DashBoardFindByIdsResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DashboardReadService {
+
+    private final DashboardRepository dashboardRepository;
+
+    public DashboardReadService(DashboardRepository dashboardRepository) {
+        this.dashboardRepository = dashboardRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public DashBoardFindByIdsResults findByIds(List<Long> dashboardIds) {
+        List<Dashboard> dashboards = dashboardRepository.findByIds(dashboardIds);
+
+        List<DashBoardFindByIdsResult> dashBoardFindByIdsResults = dashboards.stream()
+                .map(d -> new DashBoardFindByIdsResult(
+                        d.getId(),
+                        d.getLessonId()
+                )).toList();
+
+        return new DashBoardFindByIdsResults(dashBoardFindByIdsResults);
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/dashboard/service/dto/response/DashBoardFindByIdsResults.java
+++ b/src/main/java/org/guzzing/studayserver/domain/dashboard/service/dto/response/DashBoardFindByIdsResults.java
@@ -1,0 +1,15 @@
+package org.guzzing.studayserver.domain.dashboard.service.dto.response;
+
+import java.util.List;
+
+public record DashBoardFindByIdsResults(
+        List<DashBoardFindByIdsResult> dashBoards
+) {
+
+    public record DashBoardFindByIdsResult(
+            Long dashboardId,
+            Long lessonId
+    ) {
+
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/holiday/model/Holiday.java
+++ b/src/main/java/org/guzzing/studayserver/domain/holiday/model/Holiday.java
@@ -1,0 +1,40 @@
+package org.guzzing.studayserver.domain.holiday.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "holidays")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Holiday {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "date_name", nullable = false)
+    private String dateName;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    public Holiday(LocalDate date, String dateName) {
+        this.dateName = dateName;
+        this.date = date;
+    }
+
+    public String getDateName() {
+        return dateName;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/holiday/repository/HolidayRepository.java
+++ b/src/main/java/org/guzzing/studayserver/domain/holiday/repository/HolidayRepository.java
@@ -1,0 +1,12 @@
+package org.guzzing.studayserver.domain.holiday.repository;
+
+import java.util.List;
+import org.guzzing.studayserver.domain.holiday.model.Holiday;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface HolidayRepository extends JpaRepository<Holiday, Long> {
+
+    @Query("SELECT h FROM Holiday h WHERE YEAR(h.date) = :year AND MONTH(h.date) = :month")
+    List<Holiday> findByYearMonth(int year, int month);
+}

--- a/src/main/java/org/guzzing/studayserver/domain/holiday/service/HolidayService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/holiday/service/HolidayService.java
@@ -9,6 +9,7 @@ import org.guzzing.studayserver.domain.holiday.model.Holiday;
 import org.guzzing.studayserver.domain.holiday.repository.HolidayRepository;
 import org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class HolidayService {
@@ -19,6 +20,7 @@ public class HolidayService {
         this.holidayRepository = holidayRepository;
     }
 
+    @Transactional(readOnly = true)
     public HolidayFindByYearMonthResult findByYearMonth(int year, int month) {
         List<Holiday> holidays = holidayRepository.findByYearMonth(year, month);
 

--- a/src/main/java/org/guzzing/studayserver/domain/holiday/service/HolidayService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/holiday/service/HolidayService.java
@@ -1,0 +1,33 @@
+package org.guzzing.studayserver.domain.holiday.service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.guzzing.studayserver.domain.holiday.model.Holiday;
+import org.guzzing.studayserver.domain.holiday.repository.HolidayRepository;
+import org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult;
+import org.springframework.stereotype.Service;
+
+@Service
+public class HolidayService {
+
+    private final HolidayRepository holidayRepository;
+
+    public HolidayService(HolidayRepository holidayRepository) {
+        this.holidayRepository = holidayRepository;
+    }
+
+    public HolidayFindByYearMonthResult findByYearMonth(int year, int month) {
+        List<Holiday> holidays = holidayRepository.findByYearMonth(year, month);
+
+        Map<LocalDate, List<String>> holidayMap = new HashMap<>();
+
+        holidays.forEach(h ->
+            holidayMap.computeIfAbsent(h.getDate(), k -> new ArrayList<>()).add(h.getDateName())
+        );
+
+        return HolidayFindByYearMonthResult.from(holidayMap);
+    }
+}

--- a/src/main/java/org/guzzing/studayserver/domain/holiday/service/result/HolidayFindByYearMonthResult.java
+++ b/src/main/java/org/guzzing/studayserver/domain/holiday/service/result/HolidayFindByYearMonthResult.java
@@ -1,0 +1,26 @@
+package org.guzzing.studayserver.domain.holiday.service.result;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public record HolidayFindByYearMonthResult(
+        List<HolidayResult> holidayResults
+) {
+
+    public static HolidayFindByYearMonthResult from(Map<LocalDate, List<String>> holidayMap) {
+        List<HolidayResult> holidayResults = holidayMap.entrySet().stream()
+                .map(entry -> new HolidayResult(entry.getKey(), entry.getValue()))
+                .toList();
+
+        return new HolidayFindByYearMonthResult(holidayResults);
+    }
+
+    public record HolidayResult(
+            LocalDate date,
+            List<String> names
+    ) {
+
+    }
+
+}

--- a/src/main/java/org/guzzing/studayserver/domain/member/controller/response/MemberInformationResponse.java
+++ b/src/main/java/org/guzzing/studayserver/domain/member/controller/response/MemberInformationResponse.java
@@ -18,7 +18,7 @@ public record MemberInformationResponse(
     }
 
     public static MemberInformationResponse from(MemberInformationResult result) {
-        List<MemberChildInformationResponse> childInformationResponses = result.memberChildInformationResults().stream()
+        List<MemberChildInformationResponse> childInformationResponses = result.childResults().stream()
                 .map(MemberChildInformationResponse::from)
                 .toList();
 

--- a/src/main/java/org/guzzing/studayserver/domain/member/service/result/MemberInformationResult.java
+++ b/src/main/java/org/guzzing/studayserver/domain/member/service/result/MemberInformationResult.java
@@ -5,14 +5,14 @@ import java.util.List;
 public record MemberInformationResult(
         String nickname,
         String email,
-        List<MemberChildInformationResult> memberChildInformationResults
+        List<MemberChildInformationResult> childResults
 ) {
 
     public MemberInformationResult(String nickname, String email,
-            List<MemberChildInformationResult> memberChildInformationResults) {
+            List<MemberChildInformationResult> childResults) {
         this.nickname = nickname;
         this.email = email;
-        this.memberChildInformationResults = List.copyOf(memberChildInformationResults);
+        this.childResults = List.copyOf(childResults);
     }
 
     public record MemberChildInformationResult(

--- a/src/test/java/org/guzzing/studayserver/domain/calendarInfo/controller/request/CalendarMonthMarkRequestTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/calendarInfo/controller/request/CalendarMonthMarkRequestTest.java
@@ -1,0 +1,54 @@
+package org.guzzing.studayserver.domain.calendarInfo.controller.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CalendarMonthMarkRequestTest {
+
+    private static Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @ParameterizedTest
+    @MethodSource("validInputs")
+    void givenValidInput_thenNoConstraintViolations(Integer year, Integer month) {
+        // When
+        CalendarMonthMarkRequest request = new CalendarMonthMarkRequest(year, month);
+
+        // Then
+        assertThat(validator.validate(request)).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidInputs")
+    void givenInvalidInput_thenConstraintViolationIsThrown(Integer year, Integer month) {
+        // When
+        CalendarMonthMarkRequest request = new CalendarMonthMarkRequest(year, month);
+        Set<ConstraintViolation<CalendarMonthMarkRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isNotEmpty();
+    }
+
+    private static Stream<Arguments> validInputs() {
+        return Stream.of(
+                Arguments.of(2000, 1),
+                Arguments.of(2100, 12)
+        );
+    }
+
+    private static Stream<Arguments> invalidInputs() {
+        return Stream.of(
+                Arguments.of(1999, 1),
+                Arguments.of(2101, 12),
+                Arguments.of(2023, 0),
+                Arguments.of(2023, 13)
+
+        );
+    }
+}

--- a/src/test/java/org/guzzing/studayserver/domain/calendarInfo/controller/request/CalendarYearMonthMarkRequestTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/calendarInfo/controller/request/CalendarYearMonthMarkRequestTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class CalendarMonthMarkRequestTest {
+class CalendarYearMonthMarkRequestTest {
 
     private static Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
@@ -19,7 +19,7 @@ class CalendarMonthMarkRequestTest {
     @MethodSource("validInputs")
     void givenValidInput_thenNoConstraintViolations(Integer year, Integer month) {
         // When
-        CalendarMonthMarkRequest request = new CalendarMonthMarkRequest(year, month);
+        CalendarYearMonthMarkRequest request = new CalendarYearMonthMarkRequest(year, month);
 
         // Then
         assertThat(validator.validate(request)).isEmpty();
@@ -29,8 +29,8 @@ class CalendarMonthMarkRequestTest {
     @MethodSource("invalidInputs")
     void givenInvalidInput_thenConstraintViolationIsThrown(Integer year, Integer month) {
         // When
-        CalendarMonthMarkRequest request = new CalendarMonthMarkRequest(year, month);
-        Set<ConstraintViolation<CalendarMonthMarkRequest>> violations = validator.validate(request);
+        CalendarYearMonthMarkRequest request = new CalendarYearMonthMarkRequest(year, month);
+        Set<ConstraintViolation<CalendarYearMonthMarkRequest>> violations = validator.validate(request);
 
         assertThat(violations).isNotEmpty();
     }

--- a/src/test/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarFindSchedulesByDateResponsesTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/calendarInfo/controller/response/CalendarFindSchedulesByDateResponsesTest.java
@@ -1,0 +1,55 @@
+package org.guzzing.studayserver.domain.calendarInfo.controller.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.CalendarFindSchedulesByDateResults;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.CalendarFindSchedulesByDateResults.CalendarFindSchedulesByDateResult;
+import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarFindSchedulesByDateResponses.CalendarFindSchedulesByDateResponse;
+import org.guzzing.studayserver.domain.calendarInfo.controller.response.CalendarFindSchedulesByDateResponses.SameStartTimeScheduleResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CalendarFindSchedulesByDateResponsesTest {
+
+    @DisplayName("유효한 응답으로 변환되어야 한다.")
+    @Test
+    void shouldConvertedToValidResponse() {
+        // Given
+        LocalDate testDate = LocalDate.of(2023, 1, 1);
+        CalendarFindSchedulesByDateResult schedule1 = new CalendarFindSchedulesByDateResult(
+                1L,
+                101L,
+                LocalTime.of(9, 0),
+                LocalTime.of(10, 0),
+                201L,
+                "Academy A",
+                "Math");
+        CalendarFindSchedulesByDateResult schedule2 = new CalendarFindSchedulesByDateResult(
+                2L,
+                102L,
+                LocalTime.of(9, 0),
+                LocalTime.of(10, 30),
+                202L,
+                "Academy A",
+                "Science");
+        CalendarFindSchedulesByDateResults results = new CalendarFindSchedulesByDateResults(List.of(schedule1, schedule2));
+
+        // When
+        CalendarFindSchedulesByDateResponses response = CalendarFindSchedulesByDateResponses.from(testDate, results);
+
+        // 결과 검증
+        assertThat(response.date()).isEqualTo(testDate);
+
+        assertThat(response.dateResponses()).hasSize(1);
+        CalendarFindSchedulesByDateResponse actualSameStartTime = response.dateResponses().get(0);
+
+        assertThat(actualSameStartTime.schedules()).hasSize(2);
+        List<SameStartTimeScheduleResponse> schedules = actualSameStartTime.schedules();
+        assertThat(schedules.get(0).lessonId()).isEqualTo(201L);
+        assertThat(schedules.get(1).lessonId()).isEqualTo(202L);
+    }
+}

--- a/src/test/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacadeTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacadeTest.java
@@ -38,7 +38,7 @@ class CalendarFacadeTest {
 
     @DisplayName("달력 마크에 필요한 정보를 가져온다.")
     @Test
-    void getYearMonthMark_ShouldReturnCorrectResult() {
+    void findYearMonthMark_ShouldReturnCorrectResult() {
         // Given
         int year = 2023;
         int month = 5;
@@ -71,7 +71,7 @@ class CalendarFacadeTest {
                 .willReturn(academyScheduleYearMonthResults);
 
         // When
-        CalendarYearMonthMarkResult result = calendarFacade.getYearMonthMark(calendarYearMonthMarkParam);
+        CalendarYearMonthMarkResult result = calendarFacade.findYearMonthMark(calendarYearMonthMarkParam);
 
         // Assert
         assertThat(result.lastDayOfMonth()).isEqualTo(31);

--- a/src/test/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacadeTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/calendarInfo/service/CalendarFacadeTest.java
@@ -1,0 +1,81 @@
+package org.guzzing.studayserver.domain.calendarInfo.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult.HolidayResult;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.guzzing.studayserver.domain.calendar.service.AcademySchedulesReadService;
+import org.guzzing.studayserver.domain.calendar.service.dto.result.AcademyScheduleYearMonthResults;
+import org.guzzing.studayserver.domain.calendarInfo.service.param.CalendarYearMonthMarkParam;
+import org.guzzing.studayserver.domain.calendarInfo.service.result.CalendarYearMonthMarkResult;
+import org.guzzing.studayserver.domain.holiday.service.HolidayService;
+import org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult;
+import org.guzzing.studayserver.domain.member.service.MemberService;
+import org.guzzing.studayserver.domain.member.service.result.MemberInformationResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CalendarFacadeTest {
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private HolidayService holidayService;
+
+    @Mock
+    private AcademySchedulesReadService academySchedulesReadService;
+
+    @InjectMocks
+    private CalendarFacade calendarFacade;
+
+    @DisplayName("달력 마크에 필요한 정보를 가져온다.")
+    @Test
+    void getYearMonthMark_ShouldReturnCorrectResult() {
+        // Given
+        int year = 2023;
+        int month = 5;
+        long memberId = 1L;
+
+        CalendarYearMonthMarkParam calendarYearMonthMarkParam = new CalendarYearMonthMarkParam(memberId, year, month);
+
+        List<Long> childIds = List.of(1L, 2L);
+        MemberInformationResult memberInformationResult = new MemberInformationResult("nickname", "email@example.com",
+                List.of(
+                        new MemberInformationResult.MemberChildInformationResult(childIds.get(0), "Child1",
+                                "Schedule1"),
+                        new MemberInformationResult.MemberChildInformationResult(childIds.get(1), "Child2",
+                                "Schedule2")));
+        given(memberService.getById(memberId)).willReturn(memberInformationResult);
+
+        HolidayFindByYearMonthResult holidayResult = new HolidayFindByYearMonthResult(
+                List.of(
+                        new HolidayResult(LocalDate.of(year, month, 5), List.of("Holiday1")),
+                        new HolidayResult(LocalDate.of(year, month, 10), List.of("Holiday2"))));
+        given(holidayService.findByYearMonth(year, month)).willReturn(holidayResult);
+
+        AcademyScheduleYearMonthResults academyScheduleYearMonthResults = new AcademyScheduleYearMonthResults(
+                List.of(
+                        new AcademyScheduleYearMonthResults.AcademyScheduleYearMonthResult(
+                                1L, 1L, 1L, LocalDate.of(year, month, 5)),
+                        new AcademyScheduleYearMonthResults.AcademyScheduleYearMonthResult(
+                                2L, 2L, 2L, LocalDate.of(year, month, 5))));
+        given(academySchedulesReadService.getScheduleByYearMonth(childIds, year, month))
+                .willReturn(academyScheduleYearMonthResults);
+
+        // When
+        CalendarYearMonthMarkResult result = calendarFacade.getYearMonthMark(calendarYearMonthMarkParam);
+
+        // Assert
+        assertThat(result.lastDayOfMonth()).isEqualTo(31);
+        assertThat(result.holidayResults()).hasSize(2);
+        assertThat(result.existenceDays()).hasSize(1);
+    }
+}

--- a/src/test/java/org/guzzing/studayserver/domain/calendarInfo/service/util/DateUtilityTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/calendarInfo/service/util/DateUtilityTest.java
@@ -1,0 +1,34 @@
+package org.guzzing.studayserver.domain.calendarInfo.service.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DateUtilityTest {
+
+    @ParameterizedTest
+    @MethodSource("datesForLastDayOfMonthProvider")
+    void testLastDayOfMonth(int year, int month, int expectedLastDay) {
+        // When
+        int lastDay = DateUtility.getLastDayOfMonth(year, month);
+
+        // Then
+        assertThat(lastDay).isEqualTo(expectedLastDay);
+    }
+
+    static Stream<Arguments> datesForLastDayOfMonthProvider() {
+        return Stream.of(
+                Arguments.of(2021, 1, 31),
+                Arguments.of(2021, 2, 28),
+                Arguments.of(2020, 2, 29),
+                Arguments.of(2021, 4, 30),
+                Arguments.of(2021, 6, 30),
+                Arguments.of(2021, 9, 30),
+                Arguments.of(2021, 11, 30),
+                Arguments.of(2021, 12, 31)
+        );
+    }
+}

--- a/src/test/java/org/guzzing/studayserver/domain/holiday/repository/HolidayRepositoryTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/holiday/repository/HolidayRepositoryTest.java
@@ -1,0 +1,53 @@
+package org.guzzing.studayserver.domain.holiday.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.guzzing.studayserver.domain.holiday.model.Holiday;
+import org.guzzing.studayserver.testutil.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import(QuerydslTestConfig.class)
+class HolidayRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private HolidayRepository holidayRepository;
+
+    @BeforeEach
+    void setUp() {
+        Holiday newYear = new Holiday(LocalDate.of(2022, 1, 1), "New Year");
+        Holiday lunarNewYear = new Holiday(LocalDate.of(2022, 1, 22), "Lunar New Year");
+        entityManager.persist(newYear);
+        entityManager.persist(lunarNewYear);
+        entityManager.flush();
+    }
+
+    @DisplayName("해당 년,월에 공휴일을 반환한다.")
+    @Test
+    void whenFindByYearAndMonth_thenReturnHolidays() {
+        // Given
+        int year = 2022;
+        int month = 1;
+
+        // When
+        List<Holiday> foundHolidays = holidayRepository.findByYearMonth(year, month);
+
+        // Then
+        assertThat(foundHolidays).hasSize(2);
+        assertThat(foundHolidays).extracting(Holiday::getDateName).containsOnly("New Year", "Lunar New Year");
+    }
+}

--- a/src/test/java/org/guzzing/studayserver/domain/holiday/service/HolidayServiceTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/holiday/service/HolidayServiceTest.java
@@ -1,0 +1,52 @@
+package org.guzzing.studayserver.domain.holiday.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import org.guzzing.studayserver.domain.holiday.model.Holiday;
+import org.guzzing.studayserver.domain.holiday.repository.HolidayRepository;
+import org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult;
+import org.guzzing.studayserver.domain.holiday.service.result.HolidayFindByYearMonthResult.HolidayResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class HolidayServiceTest {
+
+    @Mock
+    private HolidayRepository holidayRepository;
+
+    private HolidayService holidayService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        holidayService = new HolidayService(holidayRepository);
+    }
+
+    @Test
+    void whenFindByYearMonth_thenReturnHolidayMap() {
+        // Given
+        int year = 2022;
+        int month = 1;
+        List<Holiday> mockHolidays = Arrays.asList(
+                new Holiday(LocalDate.of(year, month, 1), "New Year"),
+                new Holiday(LocalDate.of(year, month, 22), "Lunar New Year")
+        );
+        given(holidayRepository.findByYearMonth(year, month)).willReturn(mockHolidays);
+
+        // When
+        HolidayFindByYearMonthResult result = holidayService.findByYearMonth(year, month);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.holidayResults()).hasSize(2);
+        assertThat(result.holidayResults()).contains(
+                new HolidayResult(LocalDate.of(year, month, 1), List.of("New Year")),
+                new HolidayResult(LocalDate.of(year, month, 22), List.of("Lunar New Year")));
+    }
+}

--- a/src/test/java/org/guzzing/studayserver/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/member/service/MemberServiceTest.java
@@ -72,7 +72,7 @@ class MemberServiceTest {
         assertThat(result.nickname()).isEqualTo("TestUser");
         assertThat(result.email()).isEmpty();
 
-        assertThat(result.memberChildInformationResults()).isNotNull();
-        assertThat(result.memberChildInformationResults()).isEmpty();
+        assertThat(result.childResults()).isNotNull();
+        assertThat(result.childResults()).isEmpty();
     }
 }

--- a/src/test/java/org/guzzing/studayserver/testutil/QuerydslTestConfig.java
+++ b/src/test/java/org/guzzing/studayserver/testutil/QuerydslTestConfig.java
@@ -1,0 +1,14 @@
+package org.guzzing.studayserver.testutil;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class QuerydslTestConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
# 아이의 달력 표시 정보 조회
Mapping: `GET`

URL: `/calendar/marker?year=XX&month=XX`

Response:
```JSON
{
  "lastDay": 31, // 추후 제거 예정
  "holidays": [
    {
      "date": "2023-05-01",
      "names": ["Labor Day"]
    },
    {
      "date": "2023-05-15",
      "names": ["National Holiday"]
    }
  ],
  "existenceDays": [1, 3, 5, 15, 21, 28]
}
```

# 내 아이들의 하루 스케줄 조회
Mapping: `GET`

URL: `/schedules?date=XX`

Response:
```JSON
{
  "date": "2023-11-01",
  "dateResponses": [
    {
      "startTime": "08:00",
      "schedules": [
        {
          "lessonId": 101,
          "academyName": "Academy A",
          "lessonName": "Math",
          "endTime": "09:00",
          "overlappingSchedules": [
            {
              "scheduleId": 1001,
              "isRepeatable": true
            },
            {
              "scheduleId": 1002,
              "isRepeatable": false
            }
          ]
        },
        {
          "lessonId": 102,
          "academyName": "Academy B",
          "lessonName": "Science",
          "endTime": "09:00",
          "overlappingSchedules": [
            {
              "scheduleId": 1003,
              "isRepeatable": true
            }
          ]
        }
      ]
    },
    {
      "startTime": "09:30",
      "schedules": [
        {
          "lessonId": 103,
          "academyName": "Academy C",
          "lessonName": "English",
          "endTime": "10:30",
          "overlappingSchedules": [
            {
              "scheduleId": 1004,
              "isRepeatable": true
            }
          ]
        }
      ]
    }
  ]
}
```