### PR TITLE
[Feat/member] 회원 탈퇴 시 로컬 캐시 제거

### DIFF
--- a/src/main/java/org/guzzing/studayserver/domain/auth/service/AuthService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import org.guzzing.studayserver.domain.auth.repository.LogoutTokenRepository;
 import org.guzzing.studayserver.domain.auth.repository.RefreshTokenRepository;
 import org.guzzing.studayserver.domain.auth.service.dto.AuthLogoutResult;
 import org.guzzing.studayserver.domain.auth.service.dto.AuthRefreshResult;
+import org.guzzing.studayserver.domain.auth.service.dto.AuthSecedeResult;
 import org.guzzing.studayserver.global.error.response.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +45,14 @@ public class AuthService {
         }
 
         return AuthRefreshResult.of(authToken.getToken(), memberId);
+    }
+
+    @Transactional
+    public AuthSecedeResult secede(AuthToken authToken) {
+        refreshTokenRepository.deleteByAccessToken(authToken.getToken());
+        logoutTokenRepository.delete(authToken.getToken());
+
+        return new AuthSecedeResult(true);
     }
 
     @Transactional

--- a/src/main/java/org/guzzing/studayserver/domain/auth/service/dto/AuthSecedeResult.java
+++ b/src/main/java/org/guzzing/studayserver/domain/auth/service/dto/AuthSecedeResult.java
@@ -1,0 +1,7 @@
+package org.guzzing.studayserver.domain.auth.service.dto;
+
+public record AuthSecedeResult(
+        boolean isSecede
+) {
+
+}

--- a/src/main/java/org/guzzing/studayserver/domain/member/controller/MemberRestController.java
+++ b/src/main/java/org/guzzing/studayserver/domain/member/controller/MemberRestController.java
@@ -1,6 +1,10 @@
 package org.guzzing.studayserver.domain.member.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import org.guzzing.studayserver.domain.auth.jwt.AuthToken;
+import org.guzzing.studayserver.domain.auth.jwt.AuthTokenProvider;
+import org.guzzing.studayserver.domain.auth.jwt.JwtHeaderUtil;
 import org.guzzing.studayserver.domain.auth.memberId.MemberId;
 import org.guzzing.studayserver.domain.member.controller.request.MemberRegisterRequest;
 import org.guzzing.studayserver.domain.member.controller.response.MemberInformationResponse;
@@ -23,10 +27,16 @@ public class MemberRestController {
 
     private final MemberService memberService;
     private final MemberFacade memberFacade;
+    private final AuthTokenProvider authTokenProvider;
 
-    public MemberRestController(MemberService memberService, MemberFacade memberFacade) {
+    public MemberRestController(
+            MemberService memberService,
+            MemberFacade memberFacade,
+            AuthTokenProvider authTokenProvider
+    ) {
         this.memberService = memberService;
         this.memberFacade = memberFacade;
+        this.authTokenProvider = authTokenProvider;
     }
 
     @PatchMapping(
@@ -51,9 +61,13 @@ public class MemberRestController {
      */
     @DeleteMapping
     public ResponseEntity<Void> remove(
-            @MemberId final Long memberId
+            @MemberId final Long memberId,
+            HttpServletRequest request
     ) {
-        memberFacade.removeMember(memberId);
+        String appToken = JwtHeaderUtil.getAccessToken(request);
+        AuthToken authToken = authTokenProvider.convertAuthToken(appToken);
+
+        memberFacade.removeMember(memberId, authToken);
 
         return ResponseEntity
                 .noContent()

--- a/src/main/java/org/guzzing/studayserver/domain/member/service/MemberFacade.java
+++ b/src/main/java/org/guzzing/studayserver/domain/member/service/MemberFacade.java
@@ -2,6 +2,8 @@ package org.guzzing.studayserver.domain.member.service;
 
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.guzzing.studayserver.domain.auth.jwt.AuthToken;
+import org.guzzing.studayserver.domain.auth.service.AuthService;
 import org.guzzing.studayserver.domain.calendar.service.AcademyCalendarService;
 import org.guzzing.studayserver.domain.child.service.ChildService;
 import org.guzzing.studayserver.domain.child.service.result.ChildrenFindResult.ChildFindResult;
@@ -21,6 +23,7 @@ public class MemberFacade {
     private final DashboardService dashboardService;
     private final LikeService likeService;
     private final ReviewService reviewService;
+    private final AuthService authService;
 
     public MemberFacade(
             final MemberService memberService,
@@ -28,7 +31,8 @@ public class MemberFacade {
             final AcademyCalendarService calendarService,
             final DashboardService dashboardService,
             final LikeService likeService,
-            final ReviewService reviewService
+            final ReviewService reviewService,
+            AuthService authService
     ) {
         this.memberService = memberService;
         this.childService = childService;
@@ -36,10 +40,11 @@ public class MemberFacade {
         this.dashboardService = dashboardService;
         this.likeService = likeService;
         this.reviewService = reviewService;
+        this.authService = authService;
     }
 
     @Transactional
-    public void removeMember(final long memberId) {
+    public void removeMember(final long memberId, final AuthToken authToken) {
         List<Long> childIds = childService.findByMemberId(memberId).children()
                 .stream()
                 .map(ChildFindResult::childId)
@@ -51,6 +56,7 @@ public class MemberFacade {
         dashboardService.removeDashboard(childIds);
         childService.removeChild(memberId);
         memberService.remove(memberId);
+        authService.secede(authToken);
     }
 
 }

--- a/src/test/java/org/guzzing/studayserver/domain/member/controller/MemberRestControllerTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/member/controller/MemberRestControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.stream.Stream;
+import org.guzzing.studayserver.domain.auth.jwt.AuthTokenProvider;
 import org.guzzing.studayserver.domain.child.controller.request.ChildCreateRequest;
 import org.guzzing.studayserver.domain.member.controller.request.MemberRegisterRequest;
 import org.guzzing.studayserver.domain.member.service.MemberFacade;
@@ -44,6 +45,8 @@ class MemberRestControllerTest {
     private MemberService memberService;
     @MockBean
     private MemberFacade memberFacade;
+    @MockBean
+    private AuthTokenProvider authTokenProvider;
 
     @Autowired
     private ObjectMapper objectMapper;


### PR DESCRIPTION
- `secede` 메소드
  - AuthService 에서 리프레시 토큰과 로그아웃 토큰 모두 제거하는 메소드를 사용해 로컬 캐시 제거
- 구조에 대한 물음
  - Auth 도메인만큼은 서비스 로직과 분리하는 것이 좋을 것 같아, Member 쪽에서 AuthService 를 주입받아 사용했습니다.
  - 결과적으로 MemberFacade 클래스는 슈퍼클래스가 되었는데, 이를 해결할 수 있는 아이디어가 있는지 궁금합니다.