### PR TITLE
[Feat/dashboard] 대시보드 활성화 시 스케줄 중복 체크

### DIFF
--- a/src/main/java/org/guzzing/studayserver/domain/calendar/service/DateTimeOverlapChecker.java
+++ b/src/main/java/org/guzzing/studayserver/domain/calendar/service/DateTimeOverlapChecker.java
@@ -26,8 +26,8 @@ public class DateTimeOverlapChecker {
             throw new DateOverlapException(ErrorCode.DATE_TIME_OVERLAP_ERROR,
                     overlappingSchedules
                             .stream()
-                            .map(overlappingSchedule -> overlappingSchedule.getDashboardId()
-                            ).collect(Collectors.toSet()));
+                            .map(AcademySchedule::getDashboardId)
+                            .collect(Collectors.toSet()));
         }
     }
 

--- a/src/main/java/org/guzzing/studayserver/domain/dashboard/controller/vo/Schedule.java
+++ b/src/main/java/org/guzzing/studayserver/domain/dashboard/controller/vo/Schedule.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import org.guzzing.studayserver.global.exception.DashboardException;
+import org.guzzing.studayserver.global.time.TimeConverter;
 
 public record Schedule(
         @Positive Integer dayOfWeek,
@@ -21,20 +22,12 @@ public record Schedule(
             final String startTime,
             final String endTime
     ) {
-        final LocalTime start = parseTime(startTime);
-        final LocalTime end = parseTime(endTime);
+        final LocalTime start = TimeConverter.getLocalTime(startTime);
+        final LocalTime end = TimeConverter.getLocalTime(endTime);
 
         if (start.isAfter(end)) {
             throw new DashboardException("시작 시간이 종료 시간 보다 늦습니다.");
         }
-    }
-
-    private LocalTime parseTime(final String time) {
-        final List<Integer> timeData = Arrays.stream(time.split(":"))
-                .map(Integer::parseInt)
-                .toList();
-
-        return LocalTime.of(timeData.get(0), timeData.get(1));
     }
 
 }

--- a/src/main/java/org/guzzing/studayserver/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/org/guzzing/studayserver/domain/dashboard/service/DashboardService.java
@@ -1,9 +1,14 @@
 package org.guzzing.studayserver.domain.dashboard.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.guzzing.studayserver.domain.dashboard.model.Dashboard;
+import org.guzzing.studayserver.domain.dashboard.model.DashboardSchedule;
 import org.guzzing.studayserver.domain.dashboard.model.vo.FeeInfo;
 import org.guzzing.studayserver.domain.dashboard.repository.DashboardRepository;
 import org.guzzing.studayserver.domain.dashboard.repository.DashboardScheduleJpaRepository;
@@ -11,6 +16,7 @@ import org.guzzing.studayserver.domain.dashboard.service.converter.DashboardServ
 import org.guzzing.studayserver.domain.dashboard.service.dto.request.DashboardPostParam;
 import org.guzzing.studayserver.domain.dashboard.service.dto.request.DashboardPutParam;
 import org.guzzing.studayserver.domain.dashboard.service.dto.response.DashboardResult;
+import org.guzzing.studayserver.domain.dashboard.service.overlap.DashboardScheduleOverlapChecker;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,15 +27,17 @@ public class DashboardService {
     private final DashboardServiceConverter serviceConverter;
     private final DashboardRepository dashboardRepository;
     private final DashboardScheduleJpaRepository dashboardScheduleJpaRepository;
+    private final DashboardScheduleOverlapChecker dashboardScheduleOverlapChecker;
 
     public DashboardService(
             final DashboardServiceConverter serviceConverter,
             final DashboardRepository dashboardRepository,
-            final DashboardScheduleJpaRepository dashboardScheduleJpaRepository
-    ) {
+            final DashboardScheduleJpaRepository dashboardScheduleJpaRepository,
+            final DashboardScheduleOverlapChecker dashboardScheduleOverlapChecker) {
         this.serviceConverter = serviceConverter;
         this.dashboardRepository = dashboardRepository;
         this.dashboardScheduleJpaRepository = dashboardScheduleJpaRepository;
+        this.dashboardScheduleOverlapChecker = dashboardScheduleOverlapChecker;
     }
 
     @Transactional
@@ -66,8 +74,20 @@ public class DashboardService {
 
     @Transactional
     public DashboardResult toggleDashboardActiveness(final long dashboardId) {
-        final Dashboard dashboard = dashboardRepository.findDashboardById(dashboardId)
-                .toggleActive();
+        final Dashboard dashboard = dashboardRepository.findDashboardById(dashboardId);
+
+        final List<DashboardSchedule> childDashboardSchedules = dashboardRepository.findActiveOnlyByChildId(
+                        dashboard.getChildId())
+                .stream()
+                .filter(childDashboard -> !Objects.equals(dashboard.getId(), childDashboard.getId()))
+                .map(Dashboard::getDashboardSchedules)
+                .flatMap(List::stream)
+                .collect(Collectors.toCollection(() -> Collections.synchronizedList(new ArrayList<>())));
+
+        dashboardScheduleOverlapChecker.checkScheduleOverlap(dashboard.getDashboardSchedules(),
+                childDashboardSchedules);
+
+        dashboard.toggleActive();
 
         return serviceConverter.from(dashboard);
     }

--- a/src/main/java/org/guzzing/studayserver/domain/dashboard/service/overlap/DashboardScheduleOverlapChecker.java
+++ b/src/main/java/org/guzzing/studayserver/domain/dashboard/service/overlap/DashboardScheduleOverlapChecker.java
@@ -1,0 +1,39 @@
+package org.guzzing.studayserver.domain.dashboard.service.overlap;
+
+import java.util.List;
+import org.guzzing.studayserver.domain.dashboard.model.DashboardSchedule;
+import org.guzzing.studayserver.global.time.TimeConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DashboardScheduleOverlapChecker {
+
+    public void checkScheduleOverlap(
+            List<DashboardSchedule> dashboardSchedules,
+            List<DashboardSchedule> childDashboardSchedules
+    ) {
+        final long overlapCount = childDashboardSchedules.stream()
+                .filter(childDashboardSchedule -> dashboardSchedules.stream()
+                        .anyMatch(dashboardSchedule -> isScheduleOverlap(dashboardSchedule, childDashboardSchedule)))
+                .count();
+
+        if (overlapCount > 0) {
+            throw new IllegalStateException("시간이 겹치는 대시보드 스케줄이 있습니다.");
+        }
+    }
+
+    private boolean isScheduleOverlap(DashboardSchedule dashboardSchedule, DashboardSchedule childDashboardSchedule) {
+        final boolean isSameDayOfWeek = dashboardSchedule.getDayOfWeek() == childDashboardSchedule.getDayOfWeek();
+        final boolean isAfterSchedule = TimeConverter.getLocalTime(dashboardSchedule.getStartTime()).isAfter(
+                TimeConverter.getLocalTime(childDashboardSchedule.getEndTime()));
+        final boolean isBeforeSchedules = TimeConverter.getLocalTime(dashboardSchedule.getEndTime()).isBefore(
+                TimeConverter.getLocalTime(childDashboardSchedule.getStartTime()));
+        final boolean isSameStartTime = TimeConverter.getLocalTime(dashboardSchedule.getStartTime()).equals(
+                TimeConverter.getLocalTime(childDashboardSchedule.getStartTime()));
+        final boolean isSameEndTime = TimeConverter.getLocalTime(dashboardSchedule.getEndTime()).equals(
+                TimeConverter.getLocalTime(childDashboardSchedule.getEndTime()));
+
+        return isSameDayOfWeek && (isAfterSchedule || isBeforeSchedules || isSameStartTime || isSameEndTime);
+    }
+
+}

--- a/src/main/java/org/guzzing/studayserver/global/time/TimeConverter.java
+++ b/src/main/java/org/guzzing/studayserver/global/time/TimeConverter.java
@@ -1,0 +1,20 @@
+package org.guzzing.studayserver.global.time;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+public class TimeConverter {
+
+    protected TimeConverter() {
+    }
+
+    public static LocalTime getLocalTime(final String time) {
+        final List<Integer> timeData = Arrays.stream(time.split(":"))
+                .map(Integer::parseInt)
+                .toList();
+
+        return LocalTime.of(timeData.get(0), timeData.get(1));
+    }
+
+}

--- a/src/test/java/org/guzzing/studayserver/domain/dashboard/service/DashboardServiceTest.java
+++ b/src/test/java/org/guzzing/studayserver/domain/dashboard/service/DashboardServiceTest.java
@@ -103,6 +103,20 @@ class DashboardServiceTest {
     }
 
     @Test
+    @DisplayName("활성화되어 있는 기존 대시보드와 겹치는 스케쥴이 있을때 대시보드를 활성화하면 예외가 발생한다.")
+    void toggleActive_DuplicatedDashboardSchedule_Exception() {
+        // Given
+        dashboardFixture.createActiveEntity();
+
+        final Dashboard duplicatedScheduleDashboard = dashboardFixture.createNotActiveEntity();
+
+        // When & Then
+        assertThatThrownBy(() -> dashboardService.toggleDashboardActiveness(duplicatedScheduleDashboard.getId()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("시간이 겹치는 대시보드 스케줄이 있습니다.");
+    }
+
+    @Test
     @DisplayName("아이디로 대시보드를 조회한다.")
     void findDashboard_ByDashboardId() {
         // Given


### PR DESCRIPTION
### TimeConverter
- String to LocalTime 역할을 클래스로 분리했습니다.
- 영향받은 클래스
  - DashboardScheduleOverlapChecker
  - DateTimeOverlapChecker
### 주요 변경점
- 현재 활성화된 대시보드 스케줄 중에서 지금 활성화하려는 대시보드 스케줄과 겹치면(겹치거나 같거나) 예외 던지기