### PR TITLE
 r-tree index가 있으나 사용하지 못했던 쿼리 개선, N+1 문제 해결 등으로 1s에서 100ms로 응답시간 개선

### DIFF
--- a/src/main/java/org/guzzing/studayserver/domain/region/repository/RegionJpaRepository.java
+++ b/src/main/java/org/guzzing/studayserver/domain/region/repository/RegionJpaRepository.java
@@ -21,7 +21,7 @@ public interface RegionJpaRepository extends JpaRepository<Region, Long>, Region
             final String upmyeondong);
 
     @Override
-    @Query("select r from Region r where ST_Contains(r.area, :point) = true")
+    @Query("select r from Region r where ST_Contains(r.area, :point)")
     Optional<Region> findByAreaContainingPoint(@Param("point") final Point point);
 
 }


### PR DESCRIPTION
## 구현 내용
기존 학원 목록 조회에서 r-tree를 이용함에도 응답시간이 1s가 발생하는 문제가 있었습니다.
이를 해결하기 위해서
- academy-categories와의 N+1 문제를 inner join을 통해 해결하였으나 풀테이블 스캔이 발생하여  4만개의 row를 읽었습니다.
따라서 이 문제를 해결하고자 ```CREATE INDEX idx_academy_id ON academy_categories ( academy_id );```를 통해 인덱스를 만들었고 9개의 row를 읽도록 개선하였습니다.
- 또한 Facade에서 regions 를 불러와 요청하는 위,경도가 어떤 지역에 포함되는지 조회하는 쿼리가 있는데 이 부분에서 큰 병목 현상이 발생하여 응답시간이 계속 1s에서 벗어나지 못하는 문제가 발생하였습니다. 따라서 multipolygon에 대한 r-tree인덱스를 만들었습니다. 그러나 기존 쿼리에서 만들어진 r-tree index를 사용하지 못하고 테이블 풀 스캔이 발생하여 쿼리를 수정하였습니다.
```mysql
#before
SELECT
    code,
    sido,
    sigungu,
    upmyeondong,
    area,
    point 
FROM
    regions  
WHERE
    ST_CONTAINS(area, ST_SRID(Point(127.1388684, 37.4449168), 4326))=1;
  ```
 
![image](https://github.com/Guzzing/Studay_Server/assets/108210958/c827f73d-402a-431d-9baa-8101a70fe9ae)
```mysql
#after
SELECT
    code,
    sido,
    sigungu,
    upmyeondong,
    area,
    point 
FROM
    regions  
WHERE
    ST_CONTAINS(area, ST_SRID(Point(127.1388684, 37.4449168), 4326));
```
![image](https://github.com/Guzzing/Studay_Server/assets/108210958/6bc47612-66bb-4d6f-bc1f-030a26a5780f)
